### PR TITLE
feat: enforce bead and bind validation

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -7,7 +7,7 @@ This plan derives from the MVP and Beta requirements in [`prd.md`](../prd.md). I
 ### apps/server
 - Implement REST endpoints for match lifecycle: `POST /match`, `POST /match/:id/join`, `GET /match/:id`, `POST /match/:id/move`, `POST /match/:id/judge`.
 - Maintain in-memory `matches` store and broadcast state changes via WebSocket `state:update`.
-- Validate Cast and Bind moves: enforce text bead constraints, reject invalid edges, ensure deterministic judge stub.
+- Validate Cast and Bind moves: enforce text bead constraints, reject invalid edges, ensure deterministic judge stub. *(completed)*
 - Provide JSON match log export. *(completed)*
 
 ### apps/web

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -66,15 +66,25 @@ export function validateMove(move: Move, state: GameState): boolean {
     if (!bead) return false;
     if (bead.modality !== "text") return false;
     if (typeof bead.content !== "string" || bead.content.trim().length === 0) return false;
-    if (bead.content.length > 280) return false;
+    if (bead.content.length > 10_000) return false;
+    if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5) return false;
+    if (typeof bead.title === "string" && bead.title.length > 80) return false;
+    if (bead.seedId && !state.seeds.find((s) => s.id === bead.seedId)) return false;
     return true;
   }
 
   if (move.type === "bind") {
-    const { from, to, label } = move.payload ?? {};
+    const { from, to, label, justification } = move.payload ?? {};
     if (!from || !to || from === to) return false;
     if (!state.beads[from] || !state.beads[to]) return false;
-    if (!label) return false;
+    if (label !== "analogy") return false;
+    if (typeof justification !== "string" || justification.trim().length === 0)
+      return false;
+    const sentences = justification
+      .split(/[.!?]/)
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.length > 0);
+    if (sentences.length < 2) return false;
     return true;
   }
 


### PR DESCRIPTION
## Summary
- enforce PRD-compliant validation for Cast and Bind moves
- note validation as complete in development plan

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module 'node:crypto' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bee45b4958832c983206e8a90c7257