### PR TITLE
chore(server): add node types

### DIFF
--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- include Node type definitions in the server's TypeScript config to enable Node globals

## Testing
- `npm --workspace apps/server run typecheck` *(fails: Cannot find module 'fastify')*


------
https://chatgpt.com/codex/tasks/task_e_68beec1525d4832c864c9dca3c2b3afa