### PR TITLE
feat: sanitize markdown with dedicated library

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -13,7 +13,8 @@ import {
   Move,
   JudgmentScroll,
   JudgedScores,
-  validateMove
+  validateMove,
+  sanitizeMarkdown,
 } from "@gbg/types";
 
 const fastify = Fastify({ logger: false });
@@ -85,7 +86,7 @@ fastify.post<{ Params: { id: string } }>("/match/:id/join", async (req, reply) =
   if(state.players.length >= 2) return reply.code(400).send({ error: "Match full" });
   const player: Player = {
     id: randomUUID().slice(0,6),
-    handle: handle || "Player"+(state.players.length+1),
+    handle: sanitizeMarkdown(handle || "Player"+(state.players.length+1)),
     resources: { insight: 5, restraint: 2, wildAvailable: true }
   };
   state.players.push(player);
@@ -115,6 +116,20 @@ fastify.post<{ Params: { id: string } }>("/match/:id/move", async (req, reply) =
   if(!state) return reply.code(404).send({ error: "No such match" });
 
   const move = (req.body as any) as Move;
+  // sanitize text fields
+  if(move.type === "cast"){
+    const bead = move.payload?.bead as Bead;
+    if(bead){
+      bead.content = sanitizeMarkdown(bead.content);
+      if(typeof bead.title === "string"){
+        bead.title = sanitizeMarkdown(bead.title);
+      }
+    }
+  } else if(move.type === "bind"){
+    if(typeof move.payload?.justification === "string"){
+      move.payload.justification = sanitizeMarkdown(move.payload.justification);
+    }
+  }
   if(!validateMove(move, state)){
     return reply.code(400).send({ error: "Invalid move" });
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,9 +11,15 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --import tsx test/*.test.ts"
+  },
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
+    "@types/sanitize-html": "^2.16.0",
+    "tsx": "^4.16.2",
     "typescript": "^5.6.2"
   }
 }

--- a/packages/types/test/sanitizeMarkdown.test.ts
+++ b/packages/types/test/sanitizeMarkdown.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeMarkdown } from '../src/index.ts';
+
+test('removes script tags', () => {
+  const dirty = '<p>Hello<script>alert(1)</script></p>';
+  const clean = sanitizeMarkdown(dirty);
+  assert.equal(clean, '<p>Hello</p>');
+});
+
+test('strips event handlers from images', () => {
+  const dirty = '<img src="x" onerror="alert(1)">';
+  const clean = sanitizeMarkdown(dirty);
+  assert.ok(!clean.includes('onerror'));
+  assert.ok(clean.startsWith('<img'));
+});
+
+test('removes javascript URLs', () => {
+  const dirty = '<a href="javascript:alert(1)">hi</a>';
+  const clean = sanitizeMarkdown(dirty);
+  assert.equal(clean, '<a>hi</a>');
+});


### PR DESCRIPTION
## Summary
- replace regex-based sanitizer with sanitize-html helper
- sanitize user input on server and validators
- cover common XSS vectors with unit tests

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run typecheck`
- `npm --workspace apps/server run typecheck` *(fails: Cannot find module 'fastify'...)*

------
https://chatgpt.com/codex/tasks/task_e_68beec13ef80832c9cd179ce037dafc1