### PR TITLE
fix: enable React JSX in web tsconfig

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,7 +4,9 @@
     "baseUrl": ".",
     "paths": {
       "@gbg/types": ["../../packages/types/src"]
-    }
+    },
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler"
   },
   "include": ["src", "vite-env.d.ts"]
 }


### PR DESCRIPTION
## Summary
- configure web tsconfig for React JSX using bundler resolution

## Testing
- `npm --workspace apps/web run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68beec161a10832c9a7bfa4321106ad4