### PR TITLE
feat: add markdown sanitization tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:server": "npm --workspace apps/server run build",
     "typecheck": "npm-run-all -p typecheck:*",
     "typecheck:web": "npm --workspace apps/web run typecheck",
-    "typecheck:server": "npm --workspace apps/server run typecheck"
+    "typecheck:server": "npm --workspace apps/server run typecheck",
+    "test": "npx tsx --test packages/types/test/sanitizeMarkdown.test.ts"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -49,6 +49,8 @@ export interface JudgmentScroll {
 
 // --- Validation helpers ---
 
+import { sanitizeMarkdown } from "./sanitizeMarkdown";
+
 /** Validate that a seed has non-empty text and domain. */
 export function validateSeed(seed: Seed): boolean {
   return !!seed && !!seed.id && seed.text.trim().length > 0 && seed.domain.trim().length > 0;
@@ -65,8 +67,8 @@ export function validateMove(move: Move, state: GameState): boolean {
     const bead = move.payload?.bead as Bead | undefined;
     if (!bead) return false;
     if (bead.modality !== "text") return false;
+    bead.content = sanitizeMarkdown(bead.content);
     if (typeof bead.content !== "string" || bead.content.trim().length === 0) return false;
-    if (bead.content.length > 10_000) return false;
     if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5) return false;
     if (typeof bead.title === "string" && bead.title.length > 80) return false;
     if (bead.seedId && !state.seeds.find((s) => s.id === bead.seedId)) return false;
@@ -90,3 +92,5 @@ export function validateMove(move: Move, state: GameState): boolean {
 
   return true; // other move types are treated as valid for now
 }
+
+export { sanitizeMarkdown };

--- a/packages/types/src/sanitizeMarkdown.ts
+++ b/packages/types/src/sanitizeMarkdown.ts
@@ -1,0 +1,10 @@
+export function sanitizeMarkdown(input: string): string {
+  if (typeof input !== "string") return "";
+  // Remove script tags and their content
+  let out = input.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "");
+  // Enforce length cap of 10k characters
+  if (out.length > 10_000) {
+    out = out.slice(0, 10_000);
+  }
+  return out;
+}

--- a/packages/types/test/sanitizeMarkdown.test.ts
+++ b/packages/types/test/sanitizeMarkdown.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeMarkdown } from "../src/sanitizeMarkdown";
+
+test("removes script tags", () => {
+  const input = "Hello<script>alert('x')</script>World";
+  const output = sanitizeMarkdown(input);
+  assert.strictEqual(output, "HelloWorld");
+});
+
+test("limits output to 10k characters", () => {
+  const long = "a".repeat(10050);
+  const output = sanitizeMarkdown(long);
+  assert.strictEqual(output.length, 10_000);
+});


### PR DESCRIPTION
## Summary
- add root test script running TSX-based tests
- provide `sanitizeMarkdown` utility and integrate with move validation
- cover sanitizer and length cap with node-based tests

## Testing
- `npm test`
- `npm --workspace packages/types run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68beec17fe04832c883b63c73de3be44