### PR TITLE
fix: replace workspace links and document install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ Two‑player, online, AI‑judged prototype. This MVP includes:
 - A stub **Magister Ludi** judge that scores basic Resonance/Aesthetics
 
 ## Quickstart
-**Requirements:** Node 20+ (or 18+ with `--experimental‐fetch`), npm 9+
+**Requirements:** Node 20+ (or 18+ with `--experimental-fetch`), npm 9+
+
+Verify npm version and install dependencies from the repo root (no `--workspaces` flag):
 
 ```bash
-# from repo root
+npm --version  # should be 7+
 npm install
 npm run dev
 # web: http://localhost:5173  |  server: http://localhost:8787
 ```
+If `npm install` fails with `Unsupported URL Type "workspace:"`, replace any `workspace:*` entries in subpackage `package.json` files with relative `file:` links (e.g., `file:../../packages/types`).
 Open two browser windows, choose distinct handles, and join/create the same match ID.
 
 ## Scripts

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,7 +13,7 @@
     "uuid": "^9.0.1",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "@gbg/types": "workspace:*"
+    "@gbg/types": "file:../../packages/types"
   },
   "devDependencies": {
     "@types/node": "^24.3.1",


### PR DESCRIPTION
## Summary
- replace `workspace:*` dependency with relative file link in server package
- document installing dependencies and handling workspace URLs in README

## Testing
- `npm --version`
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68beec1a0a88832c8980d53f7cc17313