### PR TITLE
refine bead content validation

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -109,10 +109,12 @@ export function validateMove(move: Move, state: GameState): boolean {
     const bead = move.payload?.bead as Bead | undefined;
     if (!bead) return false;
     if (bead.modality !== "text") return false;
-    if (typeof bead.content !== "string" || bead.content.trim().length === 0) return false;
+    if (typeof bead.content !== "string") return false;
+    if (bead.content.trim().length === 0) return false;
     bead.content = sanitizeMarkdown(bead.content);
     if (bead.content.length > 10_000) return false;
-    if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5) return false;
+    if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5)
+      return false;
     if (typeof bead.title === "string") {
       bead.title = sanitizeMarkdown(bead.title);
       if (bead.title.length > 80) return false;


### PR DESCRIPTION
## Summary
- adjust cast move validation to explicitly check bead.content type, trim empties, sanitize, and enforce max length
- retain sanitizeMarkdown helper using sanitize-html

## Testing
- `npm --workspace packages/types test`

------
https://chatgpt.com/codex/tasks/task_e_68bef5dd11dc832c88bc45ef9c5da899