### PR TITLE
Ensure sanitizeMarkdown truncates output and expand tests

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -85,7 +85,8 @@ const MD_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
 };
 
 export function sanitizeMarkdown(md: string): string {
-  return sanitizeHtml(md, MD_SANITIZE_OPTIONS);
+  const clean = sanitizeHtml(md, MD_SANITIZE_OPTIONS);
+  return clean.slice(0, 10_000);
 }
 
 // --- Validation helpers ---

--- a/packages/types/test/sanitizeMarkdown.test.ts
+++ b/packages/types/test/sanitizeMarkdown.test.ts
@@ -20,3 +20,9 @@ test('removes javascript URLs', () => {
   const clean = sanitizeMarkdown(dirty);
   assert.equal(clean, '<a>hi</a>');
 });
+
+test('truncates output to 10k characters', () => {
+  const dirty = 'a'.repeat(10_050);
+  const clean = sanitizeMarkdown(dirty);
+  assert.equal(clean.length, 10_000);
+});


### PR DESCRIPTION
## Summary
- Truncate sanitized markdown output to 10k characters
- Maintain tests for removing script tags, image event handlers, and javascript URLs
- Add test verifying sanitized markdown is truncated to 10k characters

## Testing
- `npm --workspace packages/types test`

------
https://chatgpt.com/codex/tasks/task_e_68bef5dde364832cb361535f9d62faff