### PR TITLE
feat(types): add replay utilities

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -143,3 +143,34 @@ export function validateMove(move: Move, state: GameState): boolean {
 
   return true; // other move types are treated as valid for now
 }
+/**
+ * Apply a move to mutate the given game state. Supports basic `cast` and `bind` moves.
+ * Assumes the move has already been validated.
+ */
+export function applyMove(state: GameState, move: Move): void {
+  state.moves.push(move);
+  if (move.type === "cast") {
+    const bead = move.payload?.bead as Bead | undefined;
+    if (bead) {
+      state.beads[bead.id] = bead;
+    }
+  } else if (move.type === "bind") {
+    const { edgeId, from, to, label, justification } = move.payload ?? {};
+    const id = edgeId ?? move.id;
+    const edge: Edge = { id, from, to, label, justification };
+    state.edges[id] = edge;
+  }
+  state.updatedAt = move.timestamp;
+}
+
+/**
+ * Replay a sequence of moves from an initial state and return the resulting state.
+ * The initial state is not mutated.
+ */
+export function replayMoves(initial: GameState, moves: Move[]): GameState {
+  const state: GameState = JSON.parse(JSON.stringify(initial));
+  for (const m of moves) {
+    applyMove(state, m);
+  }
+  return state;
+}

--- a/packages/types/test/replay.test.ts
+++ b/packages/types/test/replay.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GameState, Move, replayMoves } from '../src/index.ts';
+
+test('replayMoves applies cast and bind moves', () => {
+  const initial: GameState = {
+    id: 'g1',
+    round: 1,
+    phase: 'play',
+    players: [],
+    seeds: [],
+    beads: {},
+    edges: {},
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const cast1: Move = {
+    id: 'm1',
+    playerId: 'p1',
+    type: 'cast',
+    payload: {
+      bead: {
+        id: 'b1',
+        ownerId: 'p1',
+        modality: 'text',
+        content: 'hello',
+        complexity: 1,
+        createdAt: 0,
+      },
+    },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+
+  const cast2: Move = {
+    id: 'm2',
+    playerId: 'p2',
+    type: 'cast',
+    payload: {
+      bead: {
+        id: 'b2',
+        ownerId: 'p2',
+        modality: 'text',
+        content: 'world',
+        complexity: 1,
+        createdAt: 0,
+      },
+    },
+    timestamp: 2,
+    durationMs: 0,
+    valid: true,
+  };
+
+  const bind: Move = {
+    id: 'm3',
+    playerId: 'p1',
+    type: 'bind',
+    payload: {
+      edgeId: 'e1',
+      from: 'b1',
+      to: 'b2',
+      label: 'analogy',
+      justification: 'First sentence. Second.',
+    },
+    timestamp: 3,
+    durationMs: 0,
+    valid: true,
+  };
+
+  const result = replayMoves(initial, [cast1, cast2, bind]);
+  assert.equal(Object.keys(result.beads).length, 2);
+  assert.ok(result.edges['e1']);
+  assert.equal(result.moves.length, 3);
+  assert.equal(initial.moves.length, 0);
+});


### PR DESCRIPTION
## Summary
- add applyMove and replayMoves helpers for reconstructing game state from move logs
- cover replay logic with node:test suite

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bef9079960832cab265c3878e76ce0