### PR TITLE
build: compile types during dev

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@fastify/cors": "^10.0.1",
+    "@fastify/cors": "^8.5.0",
     "fastify": "^4.28.1",
     "uuid": "^9.0.1",
     "ws": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "dev": "npm-run-all -p dev:*",
     "dev:web": "npm --workspace apps/web run dev",
     "dev:server": "npm --workspace apps/server run dev",
+    "dev:types": "npm --workspace packages/types run dev",
     "build": "npm-run-all -p build:*",
     "build:web": "npm --workspace apps/web run build",
     "build:server": "npm --workspace apps/server run build",
-    "typecheck": "npm-run-all -p typecheck:*",
+    "build:types": "npm --workspace packages/types run build",
+    "typecheck": "npm-run-all typecheck:types typecheck:web typecheck:server",
     "typecheck:web": "npm --workspace apps/web run typecheck",
-    "typecheck:server": "npm --workspace apps/server run typecheck"
+    "typecheck:server": "npm --workspace apps/server run typecheck",
+    "typecheck:types": "npm --workspace packages/types run build"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "dev": "tsc -w -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test --import tsx test/*.test.ts"
   },


### PR DESCRIPTION
## Summary
- watch and build `@gbg/types` during development and include in project scripts
- ensure type-checking builds shared types before dependent packages
- align `@fastify/cors` with Fastify v4 to resolve plugin mismatch

## Testing
- `npm --workspace packages/types test`
- `npm run typecheck`
- `npm run dev` (server starts at http://localhost:8787)


------
https://chatgpt.com/codex/tasks/task_e_68befe392498832cb3307ccf35525b26