### PR TITLE
build: compile types during dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
-    "dev": "npm-run-all -p dev:*",
+    "dev": "npm-run-all build:types --parallel dev:types dev:web dev:server",
     "dev:web": "npm --workspace apps/web run dev",
     "dev:server": "npm --workspace apps/server run dev",
     "dev:types": "npm --workspace packages/types run dev",


### PR DESCRIPTION
## Summary
- ensure shared types build completes before starting dev server

## Testing
- `npm --workspace packages/types test`
- `npm run typecheck`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68bf19ba2a54832ca5c49da40db8d2b2