### PR TITLE
fix(types): mark package as module

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gbg/types",
   "version": "0.1.0",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- declare @gbg/types as an ES module so named exports like `sanitizeMarkdown` are available

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf1fae79c4832ca9c1ce0113f7078a