### PR TITLE
guard websocket connection on missing match id

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,7 +29,8 @@ export default function App() {
   useEffect(() => { localStorage.setItem("matchId", matchId); }, [matchId]);
   useEffect(() => { localStorage.setItem("handle", handle); }, [handle]);
 
-  const connectWs = (id: string) => {
+  const connectWs = (id?: string) => {
+    if (!id) return;
     wsRef.current?.close();
     const ws = new WebSocket(`ws://localhost:8787/?matchId=${id}`);
     ws.onmessage = (e) => {
@@ -43,6 +44,10 @@ export default function App() {
     try {
       const res = await api("/match", { method: "POST" });
       const data = await res.json();
+      if (!data?.id) {
+        console.error("Invalid match response", data);
+        return;
+      }
       setMatchId(data.id);
       setState(data);
       connectWs(data.id);


### PR DESCRIPTION
## Summary
- avoid opening websocket when match ID is missing
- validate match creation response before connecting

## Testing
- `npm --workspace apps/web run typecheck`
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf28608f24832c97f2d72cabf165ba