### PR TITLE
docs: update README with completed features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Two‑player, online, AI‑judged prototype. This MVP includes:
 - Realtime match state (in‑memory) via Fastify + WebSocket
-- Shared TypeScript types
+- Shared TypeScript types and validation utilities
 - Vite + React web client with Tailwind and a minimal graph‑like list
+- JSON match log export (`GET /match/:id/log` or Export button in the UI)
 - A stub **Magister Ludi** judge that scores basic Resonance/Aesthetics
 
 ## Quickstart
@@ -12,13 +13,14 @@ Two‑player, online, AI‑judged prototype. This MVP includes:
 Verify npm version and install dependencies from the repo root (no `--workspaces` flag):
 
 ```bash
-npm --version  # should be 7+
+npm --version  # should be 9+
 npm install
 npm run dev
 # web: http://localhost:5173  |  server: http://localhost:8787
 ```
 If `npm install` fails with `Unsupported URL Type "workspace:"`, replace any `workspace:*` entries in subpackage `package.json` files with relative `file:` links (e.g., `file:../../packages/types`).
 Open two browser windows, choose distinct handles, and join/create the same match ID.
+To export a match log for replay or analysis, use the **Export Log** button in the UI or `GET /match/{id}/log`.
 
 ## Scripts
 - `npm run dev` — runs server + web concurrently


### PR DESCRIPTION
## Summary
- document JSON match log export and validation utilities in README
- raise npm version requirement to 9+ and mention export log instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --loader tsx --test apps/server/test/cast.test.ts` *(fails: tsx must be loaded with --import)*

------
https://chatgpt.com/codex/tasks/task_e_68bf360fab78832c9736f74714be99d7