### PR TITLE
docs: expand README with play guide and judge overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,22 @@ npm install
 npm run dev
 # web: http://localhost:5173  |  server: http://localhost:8787
 ```
-If `npm install` fails with `Unsupported URL Type "workspace:"`, replace any `workspace:*` entries in subpackage `package.json` files with relative `file:` links (e.g., `file:../../packages/types`).
+If `npm install` fails with `Unsupported URL Type "workspace:"`, replace any `workspace:*` entries in subpackage `package.json`
+files with relative `file:` links (e.g., `file:../../packages/types`).
 Open two browser windows, choose distinct handles, and join/create the same match ID.
 To export a match log for replay or analysis, use the **Export Log** button in the UI or `GET /match/{id}/log`.
+
+## How to Play (MVP)
+1. Run `npm run dev` and open the web client at `http://localhost:5173`.
+2. In two browser windows, enter the same match ID to create or join a match.
+3. Take turns casting beads (concepts) and binding them with strings (relationships).
+4. Every move is validated by the server and synced live between players.
+5. Export the log when finished for replay or analysis.
+
+## Judge v0/v1
+The current prototype includes a deterministic **Magister Ludi** judge (v0) that scores basic\
+Resonance and Aesthetics. The planned v1 upgrade introduces path embeddings for Resonance,\
+NLI contradiction checks for Integrity, and shingle/LSH rarity for Novelty.
 
 ## Scripts
 - `npm run dev` — runs server + web concurrently
@@ -31,3 +44,6 @@ To export a match log for replay or analysis, use the **Export Log** button in t
 - Data is in‑memory (ephemeral). Suitable for local testing.
 - The judge is a deterministic stub; replace with your LLM/embedding pipeline later.
 - See `/packages/types/src/index.ts` for the move schema.
+
+## Architecture
+![Architecture Diagram](docs/architecture.svg)

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="220" font-family="sans-serif" font-size="14">
+  <rect x="40" y="60" width="150" height="80" fill="#E0F7FF" stroke="#333"/>
+  <text x="115" y="100" text-anchor="middle">Client</text>
+  <text x="115" y="120" text-anchor="middle">(React/Vite)</text>
+
+  <rect x="235" y="40" width="150" height="120" fill="#E8F5E9" stroke="#333"/>
+  <text x="310" y="80" text-anchor="middle">Server</text>
+  <text x="310" y="100" text-anchor="middle">(Fastify + WS)</text>
+  <text x="310" y="120" text-anchor="middle">Match State</text>
+
+  <rect x="430" y="60" width="150" height="80" fill="#FDEBD0" stroke="#333"/>
+  <text x="505" y="100" text-anchor="middle">Judge</text>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333" />
+    </marker>
+  </defs>
+
+  <line x1="190" y1="100" x2="235" y2="100" stroke="#333" marker-end="url(#arrow)"/>
+  <line x1="235" y1="120" x2="190" y2="120" stroke="#333" marker-end="url(#arrow)"/>
+  <line x1="385" y1="100" x2="430" y2="100" stroke="#333" marker-end="url(#arrow)"/>
+  <line x1="430" y1="120" x2="385" y2="120" stroke="#333" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
## Summary
- add "How to Play" and judge overview sections to README
- include simple SVG architecture diagram under docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3eb20bd8832c9dd1ce869ae5f65b