### PR TITLE
Add package documentation and fix dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ NLI contradiction checks for Integrity, and shingle/LSH rarity for Novelty.
 
 ## Architecture
 ![Architecture Diagram](docs/architecture.svg)
+
+## Additional Documentation
+See [docs/](docs/README.md) for the project vision, product requirements, and development plan.

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,34 @@
+# Server
+
+Backend for the Glass Bead Game built with Fastify and WebSockets. The server
+maintains in‑memory matches, validates moves via `@gbg/types` helpers and emits
+state updates to connected clients.
+
+## REST endpoints
+
+- `POST /match` – create a new match and return its initial state
+- `POST /match/:id/join` – join an existing match with a handle
+- `GET /match/:id` – fetch current match state
+- `POST /match/:id/move` – submit a move; broadcast on acceptance
+- `POST /match/:id/judge` – run the stub judge and broadcast results
+- `GET /match/:id/log` – download the entire match state as JSON
+
+WebSocket connections are upgraded at `ws://localhost:8787/?matchId=ID` and
+receive `state:update` and `move:accepted` events.
+
+## Development
+
+From the repository root you can use workspace scripts:
+
+```bash
+# Start the server in watch mode on http://localhost:8787
+npm --workspace apps/server run dev
+
+# Build the compiled output to dist/
+npm --workspace apps/server run build
+
+# Type‑check without emitting output
+npm --workspace apps/server run typecheck
+```
+
+The server stores everything in memory; restarting clears active matches.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,25 @@
+# Web Client
+
+Vite + React front‑end for the Glass Bead Game. It connects to the server's REST
+and WebSocket APIs to let two players create matches, cast beads, bind them and
+request judgments.
+
+The UI uses Tailwind CSS and persists the last used match ID and handle in local
+storage for convenience.
+
+## Development
+
+Run workspace scripts from the repository root:
+
+```bash
+# Start the dev server on http://localhost:5173
+npm --workspace apps/web run dev
+
+# Create a production build
+npm --workspace apps/web run build
+
+# Type‑check the project
+npm --workspace apps/web run typecheck
+```
+
+The built assets will be output to `dist/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation Index
+
+Additional project documentation lives in this directory:
+
+- `VISION.md` – high‑level goals and guiding principles
+- `PRD.md` – product requirements for the MVP
+- `development-plan.md` – planned milestones and tasks
+- `architecture.svg` – overview of the current system architecture
+
+These documents complement the main `README.md` in the repository root.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,29 @@
+# @gbg/types
+
+Shared TypeScript types and helper utilities for the Glass Bead Game.
+
+This package exports the core domain models (`Player`, `Bead`, `Edge`, `Move`,
+`GameState` and more) along with sanitization and validation helpers such as
+`sanitizeMarkdown`, `validateSeed`, `validateMove`, `applyMove` and
+`replayMoves`.
+
+## Development
+
+From the repository root you can run the following scripts against this
+workspace:
+
+```bash
+# Build once
+npm --workspace packages/types run build
+
+# Continuous compilation
+npm --workspace packages/types run dev
+
+# Type‑check without emitting output
+npm --workspace packages/types run typecheck
+
+# Run unit tests
+npm --workspace packages/types test
+```
+
+The compiled artifacts are emitted to `dist/` and are not committed.

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -33,6 +33,6 @@ echo ""
 # Step 4: Start development server
 echo "🎮 Starting development server..."
 echo "   - Web app will be available at http://localhost:5173"
-echo "   - Server will be available at http://localhost:3000"
+echo "   - Server will be available at http://localhost:8787"
 echo ""
 npm run dev


### PR DESCRIPTION
## Summary
- add README files for server, web, shared types, and docs
- link to docs from main README
- fix dev script to reference the correct server port

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`
- `npm --workspace packages/types test`
- `node --test --import tsx apps/server/test/*.ts` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf41369784832c9469bb6b9a0102b5