### PR TITLE
feat: show active player and switch turns

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -91,7 +91,7 @@ function judge(state: GameState): JudgmentScroll {
 fastify.post("/match", async (req, reply) => {
   const id = randomUUID().slice(0,8);
   const state: GameState = {
-    id, round: 1, phase:"SeedDraw", players: [], seeds: sampleSeeds(),
+    id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds: sampleSeeds(),
     beads: {}, edges: {}, moves: [], createdAt: now(), updatedAt: now()
   };
   matches.set(id, state);
@@ -110,6 +110,9 @@ fastify.post<{ Params: { id: string } }>("/match/:id/join", async (req, reply) =
     resources: { insight: 5, restraint: 2, wildAvailable: true }
   };
   state.players.push(player);
+  if(!state.currentPlayerId){
+    state.currentPlayerId = player.id;
+  }
   state.updatedAt = now();
   broadcast(id, "state:update", state);
   return reply.send(player);
@@ -172,6 +175,11 @@ fastify.post<{ Params: { id: string } }>("/match/:id/move", async (req, reply) =
     state.edges[edge.id] = edge;
   }
   state.updatedAt = now();
+  const idx = state.players.findIndex(p=>p.id===move.playerId);
+  if(idx>=0 && state.players.length>0){
+    const next = state.players[(idx+1)%state.players.length];
+    state.currentPlayerId = next.id;
+  }
   broadcast(id, "move:accepted", move);
   broadcast(id, "state:update", state);
   logMetrics(id, move, state);

--- a/apps/server/test/cast.test.ts
+++ b/apps/server/test/cast.test.ts
@@ -33,12 +33,12 @@ test('cast move broadcasts new bead to all players', async (t) => {
     env: { ...process.env, PORT: '9999' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  await new Promise(res => setTimeout(res, 500));
+  await new Promise(res => setTimeout(res, 1000));
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://localhost:9999';
+  const base = 'http://127.0.0.1:9999';
 
   // create match
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
@@ -57,8 +57,8 @@ test('cast move broadcasts new bead to all players', async (t) => {
   await join('B');
 
   // open websockets for both players
-  const ws1 = new WebSocket(`ws://localhost:9999/?matchId=${matchId}`);
-  const ws2 = new WebSocket(`ws://localhost:9999/?matchId=${matchId}`);
+  const ws1 = new WebSocket(`ws://127.0.0.1:9999/?matchId=${matchId}`);
+  const ws2 = new WebSocket(`ws://127.0.0.1:9999/?matchId=${matchId}`);
   const initial1 = waitForMessage(ws1, 'state:update');
   const initial2 = waitForMessage(ws2, 'state:update');
   await Promise.all([

--- a/apps/server/test/match.test.ts
+++ b/apps/server/test/match.test.ts
@@ -13,12 +13,12 @@ test('players can join a match and be listed in state', async (t) => {
     env: { ...process.env, PORT: '9998' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  await new Promise(res => setTimeout(res, 500));
+  await new Promise(res => setTimeout(res, 1000));
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://localhost:9998';
+  const base = 'http://127.0.0.1:9998';
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('turn switches to next player after move', async (t) => {
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: '9997' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  await new Promise(res => setTimeout(res, 1000));
+  t.after(() => {
+    server.kill();
+  });
+
+  const base = 'http://127.0.0.1:9997';
+
+  const matchRes = await fetch(`${base}/match`, { method: 'POST' });
+  const match = await matchRes.json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+  const p2 = await join('Bob');
+
+  let stateRes = await fetch(`${base}/match/${matchId}`);
+  let state = await stateRes.json();
+  assert.equal(state.currentPlayerId, p1.id);
+
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2, 8)}`,
+    ownerId: p1.id,
+    modality: 'text',
+    title: 'Idea',
+    content: 'simple',
+    complexity: 1,
+    createdAt: Date.now(),
+    seedId: match.seeds[0]?.id
+  };
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2, 8)}`,
+    playerId: p1.id,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 1000,
+    valid: true
+  };
+  await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+
+  stateRes = await fetch(`${base}/match/${matchId}`);
+  state = await stateRes.json();
+  assert.equal(state.currentPlayerId, p2.id);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,8 @@ export default function App() {
   const [scroll, setScroll] = useState<JudgmentScroll | null>(null);
   const [beadText, setBeadText] = useState("");
   const wsRef = useRef<WebSocket | null>(null);
+  const currentPlayer = state?.players.find(p => p.id === state.currentPlayerId);
+  const isMyTurn = currentPlayer?.id === playerId;
 
   useEffect(() => { localStorage.setItem("matchId", matchId); }, [matchId]);
   useEffect(() => { localStorage.setItem("handle", handle); }, [handle]);
@@ -175,6 +177,14 @@ export default function App() {
             <button onClick={joinMatch} className="px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Join</button>
           </div>
         </div>
+        {state && (
+          <div className="pt-4">
+            <h2 className="text-sm uppercase tracking-wide text-[var(--muted)]">Turn</h2>
+            <p className="text-sm mt-1">
+              {currentPlayer?.handle || currentPlayer?.id || ""} {isMyTurn && "(your turn)"}
+            </p>
+          </div>
+        )}
         <div className="pt-4">
           <h2 className="text-sm uppercase tracking-wide text-[var(--muted)]">Seeds</h2>
           <ul className="text-sm mt-2 space-y-1">
@@ -193,13 +203,13 @@ export default function App() {
           />
           <button
             onClick={castBead}
-            disabled={!beadText.trim()}
+            disabled={!beadText.trim() || !isMyTurn}
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cast Bead
           </button>
-          <button onClick={bindFirstTwo} className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500">Bind First Two</button>
-          <button onClick={requestJudgment} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500">Request Judgment</button>
+          <button onClick={bindFirstTwo} disabled={!isMyTurn} className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed">Bind First Two</button>
+          <button onClick={requestJudgment} disabled={!isMyTurn} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed">Request Judgment</button>
           <button onClick={exportLog} className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Export Log</button>
         </div>
         <p className="text-xs text-[var(--muted)] pt-4">MVP: cast text beads, bind, get a stub judgment.</p>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,7 @@ export interface Cathedral { id: string; content: string; references: string[]; 
 
 export interface GameState {
   id: string; round: 1|2|3|4; phase: string; players: Player[];
+  currentPlayerId?: string;
   seeds: Seed[]; beads: Record<string,Bead>; edges: Record<string,Edge>; moves: Move[];
   twist?: ConstraintCard; cathedral?: Cathedral; createdAt: number; updatedAt: number;
 }


### PR DESCRIPTION
## Summary
- track `currentPlayerId` in game state and rotate after moves
- display current turn in web UI and disable actions for other players
- cover turn rotation with a new server test

## Testing
- `npm run typecheck`
- `(cd apps/server && npx tsx --test test/*.test.ts)`


------
https://chatgpt.com/codex/tasks/task_e_68bf40d16a98832c8349ea4dfeeb7c55