### PR TITLE
feat(types): add graph utilities

### DIFF
--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -1,0 +1,83 @@
+import type { Bead, Edge } from "./index.js";
+
+export interface GraphState {
+  beads: Record<string, Bead>;
+  edges: Record<string, Edge>;
+  outbound: Record<string, string[]>; // edge ids keyed by source bead
+  inbound: Record<string, string[]>; // edge ids keyed by target bead
+}
+
+export function addBead(state: GraphState, bead: Bead): void {
+  state.beads[bead.id] = bead;
+  if (!state.outbound[bead.id]) state.outbound[bead.id] = [];
+  if (!state.inbound[bead.id]) state.inbound[bead.id] = [];
+}
+
+export function addEdge(state: GraphState, edge: Edge): void {
+  state.edges[edge.id] = edge;
+  if (!state.outbound[edge.from]) state.outbound[edge.from] = [];
+  state.outbound[edge.from].push(edge.id);
+  if (!state.inbound[edge.to]) state.inbound[edge.to] = [];
+  state.inbound[edge.to].push(edge.id);
+}
+
+export function removeEdge(state: GraphState, edgeId: string): void {
+  const edge = state.edges[edgeId];
+  if (!edge) return;
+  state.outbound[edge.from] = (state.outbound[edge.from] || []).filter((id) => id !== edgeId);
+  state.inbound[edge.to] = (state.inbound[edge.to] || []).filter((id) => id !== edgeId);
+  delete state.edges[edgeId];
+}
+
+export function neighbors(state: GraphState, nodeId: string): string[] {
+  const outs = (state.outbound[nodeId] || []).map((id) => state.edges[id]?.to);
+  const ins = (state.inbound[nodeId] || []).map((id) => state.edges[id]?.from);
+  return Array.from(new Set([...outs, ...ins].filter(Boolean)));
+}
+
+export function longestPathFrom(state: GraphState, start: string): string[] {
+  const visited = new Set<string>();
+
+  function dfs(node: string): string[] {
+    visited.add(node);
+    let best: string[] = [node];
+    for (const edgeId of state.outbound[node] || []) {
+      const edge = state.edges[edgeId];
+      if (!edge || visited.has(edge.to)) continue;
+      const path = dfs(edge.to);
+      if (path.length + 1 > best.length) {
+        best = [node, ...path];
+      }
+    }
+    visited.delete(node);
+    return best;
+  }
+
+  return dfs(start);
+}
+
+export function maxWeightedPathFrom(
+  state: GraphState,
+  start: string,
+  weightFn: (edge: Edge) => number
+): { path: string[]; weight: number } {
+  const visited = new Set<string>();
+
+  function dfs(node: string): { path: string[]; weight: number } {
+    visited.add(node);
+    let best: { path: string[]; weight: number } = { path: [node], weight: 0 };
+    for (const edgeId of state.outbound[node] || []) {
+      const edge = state.edges[edgeId];
+      if (!edge || visited.has(edge.to)) continue;
+      const child = dfs(edge.to);
+      const total = child.weight + weightFn(edge);
+      if (total > best.weight) {
+        best = { path: [node, ...child.path], weight: total };
+      }
+    }
+    visited.delete(node);
+    return best;
+  }
+
+  return dfs(start);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -174,3 +174,5 @@ export function replayMoves(initial: GameState, moves: Move[]): GameState {
   }
   return state;
 }
+
+export * from './graph.js';

--- a/packages/types/test/graph.test.ts
+++ b/packages/types/test/graph.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GraphState,
+  addBead,
+  addEdge,
+  removeEdge,
+  neighbors,
+  longestPathFrom,
+  maxWeightedPathFrom,
+} from '../src/graph.ts';
+import type { Bead, Edge } from '../src/index.ts';
+
+test('add and remove edges update adjacency lists', () => {
+  const state: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const a: Bead = { id: 'a', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  const b: Bead = { id: 'b', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  const c: Bead = { id: 'c', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  addBead(state, a);
+  addBead(state, b);
+  addBead(state, c);
+
+  const e1: Edge = { id: 'e1', from: 'a', to: 'b', label: 'analogy', justification: '' };
+  const e2: Edge = { id: 'e2', from: 'b', to: 'c', label: 'analogy', justification: '' };
+  const e3: Edge = { id: 'e3', from: 'a', to: 'c', label: 'analogy', justification: '' };
+  addEdge(state, e1);
+  addEdge(state, e2);
+  addEdge(state, e3);
+
+  assert.deepEqual(new Set(neighbors(state, 'a')), new Set(['b', 'c']));
+  removeEdge(state, 'e3');
+  assert.deepEqual(new Set(neighbors(state, 'a')), new Set(['b']));
+  assert.ok(!state.edges['e3']);
+});
+
+test('longest and weighted path search', () => {
+  const state: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const beads: Bead[] = ['a', 'b', 'c'].map((id) => ({
+    id,
+    ownerId: 'p',
+    modality: 'text',
+    content: '',
+    complexity: 1,
+    createdAt: 0,
+  }));
+  beads.forEach((b) => addBead(state, b));
+
+  const edges: Edge[] = [
+    { id: 'e1', from: 'a', to: 'b', label: 'analogy', justification: '' },
+    { id: 'e2', from: 'b', to: 'c', label: 'analogy', justification: '' },
+    { id: 'e3', from: 'a', to: 'c', label: 'analogy', justification: '' },
+  ];
+  edges.forEach((e) => addEdge(state, e));
+
+  const longest = longestPathFrom(state, 'a');
+  assert.deepEqual(longest, ['a', 'b', 'c']);
+
+  const weightFn = (edge: Edge) => ({ e1: 2, e2: 5, e3: 1 }[edge.id] ?? 0);
+  const weighted = maxWeightedPathFrom(state, 'a', weightFn);
+  assert.deepEqual(weighted.path, ['a', 'b', 'c']);
+  assert.equal(weighted.weight, 7);
+});


### PR DESCRIPTION
## Summary
- implement graph state and adjacency helpers
- provide longest and weighted path search utilities
- add tests for graph operations and path finding

## Testing
- `npm run typecheck --workspace packages/types`
- `npm test --workspace packages/types`


------
https://chatgpt.com/codex/tasks/task_e_68bf4246de88832c9c9aadd54ab1cd0d