### PR TITLE
Enforce move resource costs and apply resources in moves

### DIFF
--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -1,0 +1,141 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function startServer(port: number){
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore','pipe','pipe']
+  });
+  return server;
+}
+
+test('cast rejects when insight and wild exhausted', async (t) => {
+  const port = 9997;
+  const server = startServer(port);
+  await new Promise(r => setTimeout(r, 500));
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('A');
+  await join('B');
+
+  const cast = async () => {
+    const bead = {
+      id: `b_${Math.random().toString(36).slice(2,8)}`,
+      ownerId: p1.id,
+      modality: 'text',
+      content: 'x',
+      complexity: 1,
+      createdAt: Date.now()
+    };
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p1.id,
+      type: 'cast',
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    return fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+  };
+
+  // spend 5 insight and 1 wild
+  for(let i=0;i<6;i++){
+    const res = await cast();
+    assert.equal(res.status, 200);
+  }
+
+  // verify resources exhausted
+  const state = await (await fetch(`${base}/match/${matchId}`)).json();
+  const player = state.players.find((p:any)=>p.id===p1.id);
+  assert.equal(player.resources.insight, 0);
+  assert.equal(player.resources.wildAvailable, false);
+
+  // seventh cast should be rejected
+  const res = await cast();
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Not enough insight');
+});
+
+test('bind uses restraint then wild then rejects', async (t) => {
+  const port = 9996;
+  const server = startServer(port);
+  await new Promise(r => setTimeout(r, 500));
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('A');
+  await join('B');
+
+  // cast two beads to bind
+  const castBead = async (id:string) => {
+    const bead = { id, ownerId: p1.id, modality: 'text', content: 'y', complexity:1, createdAt:Date.now() };
+    const move = { id:`m_${Math.random().toString(36).slice(2,8)}`, playerId:p1.id, type:'cast', payload:{ bead }, timestamp:Date.now(), durationMs:0, valid:true };
+    await fetch(`${base}/match/${matchId}/move`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(move)});
+  };
+  const b1 = `b_${Math.random().toString(36).slice(2,8)}`;
+  const b2 = `b_${Math.random().toString(36).slice(2,8)}`;
+  await castBead(b1); await castBead(b2);
+
+  const bind = async () => {
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p1.id,
+      type: 'bind',
+      payload: { from: b1, to: b2, label: 'analogy', justification: 'First. Second.' },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    return fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+  };
+
+  // spend 2 restraint and 1 wild
+  for(let i=0;i<3;i++){
+    const res = await bind();
+    assert.equal(res.status, 200);
+  }
+
+  // fourth bind should be rejected
+  const res = await bind();
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Not enough restraint');
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,45 +103,73 @@ export function validateSeed(seed: Seed): boolean {
  * Validate a move against a given game state. Currently supports basic rules for
  * `cast` and `bind` moves.
  */
-export function validateMove(move: Move, state: GameState): boolean {
-  if (!move || !state) return false;
+export interface ValidationResult { ok: boolean; error?: string }
+
+const MOVE_COSTS: Record<MoveType, { insight?: number; restraint?: number }> = {
+  cast: { insight: 1 },
+  bind: { restraint: 1 },
+  transmute: { insight: 1 },
+  lift: { insight: 1 },
+  refute: { restraint: 1 },
+  canonize: { insight: 1, restraint: 1 },
+  prune: { restraint: 1 },
+  mirror: { insight: 1 },
+  joker: {}
+};
+
+export function validateMove(move: Move, state: GameState): ValidationResult {
+  if (!move || !state) return { ok: false, error: "Missing move or state" };
+  const player = state.players.find((p) => p.id === move.playerId);
+  if (!player) return { ok: false, error: "Unknown player" };
+
+  const cost = MOVE_COSTS[move.type] ?? {};
+  const insightShort = Math.max(0, (cost.insight ?? 0) - player.resources.insight);
+  const restraintShort = Math.max(0, (cost.restraint ?? 0) - player.resources.restraint);
+  const wild = player.resources.wildAvailable ? 1 : 0;
+  if (insightShort + restraintShort > wild) {
+    if (insightShort && restraintShort)
+      return { ok: false, error: "Not enough insight and restraint" };
+    if (insightShort) return { ok: false, error: "Not enough insight" };
+    if (restraintShort) return { ok: false, error: "Not enough restraint" };
+  }
 
   if (move.type === "cast") {
     const bead = move.payload?.bead as Bead | undefined;
-    if (!bead) return false;
-    if (bead.modality !== "text") return false;
-    if (typeof bead.content !== "string") return false;
-    if (bead.content.trim().length === 0) return false;
+    if (!bead) return { ok: false, error: "Missing bead" };
+    if (bead.modality !== "text") return { ok: false, error: "Only text beads allowed" };
+    if (typeof bead.content !== "string") return { ok: false, error: "Invalid content" };
+    if (bead.content.trim().length === 0) return { ok: false, error: "Empty content" };
     bead.content = sanitizeMarkdown(bead.content);
-    if (bead.content.length > 10_000) return false;
+    if (bead.content.length > 10_000) return { ok: false, error: "Content too long" };
     if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5)
-      return false;
+      return { ok: false, error: "Invalid complexity" };
     if (typeof bead.title === "string") {
       bead.title = sanitizeMarkdown(bead.title);
-      if (bead.title.length > 80) return false;
+      if (bead.title.length > 80) return { ok: false, error: "Title too long" };
     }
-    if (bead.seedId && !state.seeds.find((s) => s.id === bead.seedId)) return false;
-    return true;
+    if (bead.seedId && !state.seeds.find((s) => s.id === bead.seedId))
+      return { ok: false, error: "Unknown seed" };
+    return { ok: true };
   }
 
   if (move.type === "bind") {
     const { from, to, label, justification } = move.payload ?? {};
-    if (!from || !to || from === to) return false;
-    if (!state.beads[from] || !state.beads[to]) return false;
-    if (label !== "analogy") return false;
+    if (!from || !to || from === to) return { ok: false, error: "Invalid endpoints" };
+    if (!state.beads[from] || !state.beads[to]) return { ok: false, error: "Bead not found" };
+    if (label !== "analogy") return { ok: false, error: "Unsupported relation" };
     if (typeof justification !== "string" || justification.trim().length === 0)
-      return false;
+      return { ok: false, error: "Missing justification" };
     const cleanJust = sanitizeMarkdown(justification);
     move.payload.justification = cleanJust;
     const sentences = cleanJust
       .split(/[.!?]/)
       .map((s: string) => s.trim())
       .filter((s: string) => s.length > 0);
-    if (sentences.length < 2) return false;
-    return true;
+    if (sentences.length < 2) return { ok: false, error: "Need two sentences" };
+    return { ok: true };
   }
 
-  return true; // other move types are treated as valid for now
+  return { ok: true }; // other move types are treated as valid for now
 }
 /**
  * Apply a move to mutate the given game state. Supports basic `cast` and `bind` moves.
@@ -161,6 +189,30 @@ export function applyMove(state: GameState, move: Move): void {
     state.edges[id] = edge;
   }
   state.updatedAt = move.timestamp;
+}
+
+/** Apply a move and deduct resource costs from the acting player. */
+export function applyMoveWithResources(state: GameState, move: Move): void {
+  applyMove(state, move);
+  const player = state.players.find((p) => p.id === move.playerId);
+  if (!player) return;
+  const cost = MOVE_COSTS[move.type] ?? {};
+  if (cost.insight) {
+    if (player.resources.insight >= cost.insight) {
+      player.resources.insight -= cost.insight;
+    } else if (player.resources.wildAvailable) {
+      player.resources.wildAvailable = false;
+      player.resources.insight = 0;
+    }
+  }
+  if (cost.restraint) {
+    if (player.resources.restraint >= cost.restraint) {
+      player.resources.restraint -= cost.restraint;
+    } else if (player.resources.wildAvailable) {
+      player.resources.wildAvailable = false;
+      player.resources.restraint = 0;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- enforce insight/restraint/wild resource costs during move validation
- add `applyMoveWithResources` to mutate player resources when moves succeed
- update server move endpoint to use resource-aware helper and surface specific errors
- test cast/bind resource exhaustion and wild resource usage

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test --import tsx packages/types/test/*.test.ts`
- `node --test --import tsx apps/server/test/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf4247f590832cba9df2175ae73a46