### PR TITLE
refactor: modular judge pipeline

### DIFF
--- a/apps/server/src/judge/aesthetics.ts
+++ b/apps/server/src/judge/aesthetics.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount }: { beadCount: number }): number {
+  return Math.min(1, beadCount > 0 ? 0.3 + 0.05 * beadCount : 0.2);
+}

--- a/apps/server/src/judge/index.ts
+++ b/apps/server/src/judge/index.ts
@@ -1,0 +1,40 @@
+import { GameState, JudgedScores, JudgmentScroll } from '@gbg/types';
+import { score as resonance } from './resonance.js';
+import { score as novelty } from './novelty.js';
+import { score as integrity } from './integrity.js';
+import { score as aesthetics } from './aesthetics.js';
+import { score as resilience } from './resilience.js';
+
+const WEIGHTS = {
+  resonance: 0.30,
+  novelty: 0.20,
+  integrity: 0.20,
+  aesthetics: 0.20,
+  resilience: 0.10,
+} as const;
+
+export function judge(state: GameState): JudgmentScroll {
+  const scores: Record<string, JudgedScores> = {};
+
+  for (const p of state.players) {
+    const beadCount = Object.values(state.beads).filter(b => b.ownerId === p.id).length;
+    const edgeCount = Object.values(state.edges).filter(e => {
+      const owns = state.beads[e.from]?.ownerId === p.id || state.beads[e.to]?.ownerId === p.id;
+      return owns;
+    }).length;
+    const slice = { beadCount, edgeCount };
+    const r = resonance(slice);
+    const n = novelty(slice);
+    const i = integrity(slice);
+    const a = aesthetics(slice);
+    const rs = resilience(slice);
+    const total = WEIGHTS.resonance * r + WEIGHTS.novelty * n +
+      WEIGHTS.integrity * i + WEIGHTS.aesthetics * a + WEIGHTS.resilience * rs;
+    scores[p.id] = { resonance: r, novelty: n, integrity: i, aesthetics: a, resilience: rs, total };
+  }
+
+  const winner = Object.entries(scores).sort((a, b) => b[1].total - a[1].total)[0]?.[0];
+  return { winner, scores, strongPaths: [], weakSpots: [], missedFuse: undefined };
+}
+
+export default judge;

--- a/apps/server/src/judge/integrity.ts
+++ b/apps/server/src/judge/integrity.ts
@@ -1,0 +1,3 @@
+export function score({ edgeCount }: { edgeCount: number }): number {
+  return 0.5 + 0.1 * Math.tanh(edgeCount / 5);
+}

--- a/apps/server/src/judge/novelty.ts
+++ b/apps/server/src/judge/novelty.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount }: { beadCount: number }): number {
+  return 0.4 + 0.1 * Math.tanh(beadCount / 4);
+}

--- a/apps/server/src/judge/resilience.ts
+++ b/apps/server/src/judge/resilience.ts
@@ -1,0 +1,3 @@
+export function score(_: { beadCount: number; edgeCount: number }): number {
+  return 0.5;
+}

--- a/apps/server/src/judge/resonance.ts
+++ b/apps/server/src/judge/resonance.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount, edgeCount }: { beadCount: number; edgeCount: number }): number {
+  return Math.min(1, (edgeCount / Math.max(1, beadCount)) * 0.6 + 0.2);
+}

--- a/apps/server/test/judge.test.ts
+++ b/apps/server/test/judge.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import judge from '../src/judge/index.ts';
+import { GameState } from '@gbg/types';
+
+test('judge produces deterministic scores and winner', () => {
+  const state: GameState = {
+    id: 'm1',
+    round: 1,
+    phase: 'play',
+    players: [
+      { id: 'p1', handle: 'A', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+      { id: 'p2', handle: 'B', resources: { insight: 0, restraint: 0, wildAvailable: false } }
+    ],
+    seeds: [],
+    beads: {
+      b1: { id: 'b1', ownerId: 'p1', modality: 'text', content: 'b1', complexity: 1, createdAt: 0 },
+      b2: { id: 'b2', ownerId: 'p1', modality: 'text', content: 'b2', complexity: 1, createdAt: 0 },
+      b3: { id: 'b3', ownerId: 'p2', modality: 'text', content: 'b3', complexity: 1, createdAt: 0 }
+    },
+    edges: {
+      e1: { id: 'e1', from: 'b1', to: 'b3', label: 'analogy', justification: '' },
+      e2: { id: 'e2', from: 'b2', to: 'b3', label: 'analogy', justification: '' },
+      e3: { id: 'e3', from: 'b1', to: 'b2', label: 'analogy', justification: '' }
+    },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0
+  };
+
+  const scroll = judge(state);
+  assert.equal(scroll.winner, 'p1');
+  assert.ok(Math.abs(scroll.scores['p1'].total - 0.629983334485161) < 1e-9);
+  assert.ok(Math.abs(scroll.scores['p2'].total - 0.6124973524931787) < 1e-9);
+});


### PR DESCRIPTION
## Summary
- modularize judging logic into dedicated axis modules
- compute weighted totals and winners via new judge pipeline
- add deterministic judge unit test

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test --import tsx apps/server/test/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf42496b20832cb545aa1f7fff291f