### PR TITLE
feat: add twist enforcement and counterpoint move

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -88,6 +88,11 @@ A competitive, collaborative game of idea‑weaving. Two players place **beads**
 * **US‑12 (Concordance):** We co‑author a final Cathedral node with references.
 * **US‑13 (Force‑Graph):** I can manipulate a spatial graph of beads and strings.
 
+**Beta features:**
+
+* **Twist enforcement:** Constraint cards may lock allowed modalities or require a specific relation label, and the move validator must reject moves that violate the active twist.
+* **Counterpoint move:** Players can create a counterpoint referencing an opponent's bead in another modality; transformation logic is stubbed for later implementation.
+
 ---
 
 ## 6. Functional Requirements (numbered)
@@ -130,6 +135,7 @@ A competitive, collaborative game of idea‑weaving. Two players place **beads**
 * **GBG‑REQ‑060:** Add Twists with enforcement in validator.
 * **GBG‑REQ‑061:** Add non‑text modalities and transmute/mirror moves.
 * **GBG‑REQ‑062:** Add Concordance composer and final Cathedral node.
+* **GBG‑REQ‑063:** Introduce Counterpoint move targeting an opponent's bead.
 
 ---
 

--- a/packages/types/test/validateMove.test.ts
+++ b/packages/types/test/validateMove.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GameState, Move, validateMove } from '../src/index.ts';
+
+const baseState: GameState = {
+  id: 'g',
+  round: 1,
+  phase: 'play',
+  players: [
+    { id: 'p1', handle: 'p1', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+    { id: 'p2', handle: 'p2', resources: { insight: 0, restraint: 0, wildAvailable: false } }
+  ],
+  seeds: [],
+  beads: {},
+  edges: {},
+  moves: [],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+test('cast respects twist modality lock', () => {
+  const state: GameState = {
+    ...baseState,
+    twist: { id: 't', name: 'only image', description: '', effect: { modalityLock: ['image'] } }
+  };
+  const move: Move = {
+    id: 'm1',
+    playerId: 'p1',
+    type: 'cast',
+    payload: {
+      bead: { id: 'b1', ownerId: 'p1', modality: 'text', content: 'hi', complexity: 1, createdAt: 0 }
+    },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(move, state), false);
+});
+
+test('bind respects required relation from twist', () => {
+  const state: GameState = {
+    ...baseState,
+    beads: {
+      a: { id: 'a', ownerId: 'p1', modality: 'text', content: 'A', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p2', modality: 'text', content: 'B', complexity: 1, createdAt: 0 },
+    },
+    twist: { id: 't', name: 'causality only', description: '', effect: { requiredRelation: 'causality' } },
+  };
+  const move: Move = {
+    id: 'm2',
+    playerId: 'p1',
+    type: 'bind',
+    payload: { from: 'a', to: 'b', label: 'analogy', justification: 'First. Second.' },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(move, state), false);
+});
+
+test('counterpoint references opponent bead', () => {
+  const state: GameState = {
+    ...baseState,
+    beads: {
+      x: { id: 'x', ownerId: 'p2', modality: 'text', content: 'X', complexity: 1, createdAt: 0 },
+    },
+  };
+  const move: Move = {
+    id: 'm3',
+    playerId: 'p1',
+    type: 'counterpoint',
+    payload: { targetId: 'x' },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(move, state), true);
+  const badMove: Move = { ...move, payload: { targetId: 'missing' } };
+  assert.equal(validateMove(badMove, state), false);
+});


### PR DESCRIPTION
## Summary
- extend move types with `counterpoint` and enforce twist constraints in `validateMove`
- stub counterpoint apply logic and add tests for twist and counterpoint validation
- document twist enforcement and counterpoint as beta features in PRD

## Testing
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf424fa09c832c960b708eb9198f21