### PR TITLE
Resolve server merge and add judge heuristics tests

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import {
   Player,
   Bead,
   Move,
+  JudgmentScroll,
   validateMove,
   applyMoveWithResources,
   sanitizeMarkdown,
@@ -149,7 +150,7 @@ fastify.post<{ Params: { id: string } }>("/match/:id/judge", async (req, reply) 
   const id = req.params.id;
   const state = matches.get(id);
   if(!state) return reply.code(404).send({ error: "No such match" });
-  const scroll = judge(state);
+  const scroll: JudgmentScroll = judge(state);
   broadcast(id, "end:judgment", scroll);
   return reply.send(scroll);
 });

--- a/apps/server/test/heuristics.test.ts
+++ b/apps/server/test/heuristics.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { checkIntegrity } from '../../../judge/integrity';
+import { evaluateAesthetics } from '../../../judge/aesthetics';
+import { judge } from '../../../judge';
+import { GameState, Bead, Edge } from '@gbg/types';
+
+function sampleState(): GameState {
+  return {
+    id: 'm1',
+    round: 1,
+    phase: 'Play',
+    players: [
+      { id: 'p1', handle: 'A', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+      { id: 'p2', handle: 'B', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+    ],
+    seeds: [],
+    beads: {},
+    edges: {},
+    moves: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+test('checkIntegrity flags contradictory bind', () => {
+  const state = sampleState();
+  const bead1: Bead = { id: 'b1', ownerId: 'p1', modality: 'text', title: 'Love', content: 'love.', complexity: 1, createdAt: Date.now() };
+  const bead2: Bead = { id: 'b2', ownerId: 'p2', modality: 'text', title: 'Hate', content: 'hate.', complexity: 1, createdAt: Date.now() };
+  state.beads[bead1.id] = bead1;
+  state.beads[bead2.id] = bead2;
+  const edge: Edge = { id: 'e1', from: 'b1', to: 'b2', label: 'analogy', justification: 'These are similar ideas.' };
+  state.edges[edge.id] = edge;
+
+  const res = checkIntegrity(state);
+  assert.deepStrictEqual(res.flagged, ['e1']);
+});
+
+test('evaluateAesthetics considers formatting and variance', () => {
+  const rich: Bead = {
+    id: 'b1',
+    ownerId: 'p1',
+    modality: 'text',
+    content: 'Short. **This is a much longer sentence with bold text**.',
+    complexity: 1,
+    createdAt: Date.now(),
+  };
+  const plain: Bead = {
+    id: 'b2',
+    ownerId: 'p1',
+    modality: 'text',
+    content: 'One short sentence.',
+    complexity: 1,
+    createdAt: Date.now(),
+  };
+  const richScore = evaluateAesthetics([rich]);
+  const plainScore = evaluateAesthetics([plain]);
+  assert.ok(richScore > plainScore);
+});
+
+test('judge pipeline integrates heuristics', () => {
+  const state = sampleState();
+  const bead1: Bead = { id: 'b1', ownerId: 'p1', modality: 'text', title: 'Love', content: 'Love. **Bold** statement.', complexity: 1, createdAt: Date.now() };
+  const bead2: Bead = { id: 'b2', ownerId: 'p2', modality: 'text', title: 'Hate', content: 'Hate.', complexity: 1, createdAt: Date.now() };
+  state.beads[bead1.id] = bead1;
+  state.beads[bead2.id] = bead2;
+  const edge: Edge = { id: 'e1', from: 'b1', to: 'b2', label: 'analogy', justification: 'These are similar ideas.' };
+  state.edges[edge.id] = edge;
+
+  const scroll = judge(state);
+  assert.ok(scroll.weakSpots.includes('e1'));
+  const p1 = scroll.scores['p1'];
+  const p2 = scroll.scores['p2'];
+  assert.ok(p1.integrity < 1);
+  assert.ok(p1.aesthetics > p2.aesthetics);
+});

--- a/judge/aesthetics.ts
+++ b/judge/aesthetics.ts
@@ -1,0 +1,34 @@
+import { Bead } from "@gbg/types";
+
+/** Compute an aesthetics score [0,1] for a set of text beads. */
+export function evaluateAesthetics(beads: Bead[]): number {
+  const textBeads = beads.filter((b) => b.modality === "text");
+  if (textBeads.length === 0) return 0.2; // minimal baseline
+
+  const sentenceLengths: number[] = [];
+  let formattingBoost = 0;
+
+  for (const bead of textBeads) {
+    const sentences = bead.content
+      .split(/[.!?]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    for (const s of sentences) {
+      sentenceLengths.push(s.split(/\s+/).length);
+    }
+    if (/[*_`#>\[\]!]/.test(bead.content)) {
+      formattingBoost += 1;
+    }
+  }
+
+  const mean = sentenceLengths.reduce((a, b) => a + b, 0) / sentenceLengths.length;
+  const variance =
+    sentenceLengths.reduce((sum, l) => sum + Math.pow(l - mean, 2), 0) /
+    sentenceLengths.length;
+  // Map variance to [0,1] where more variation increases the score but saturates.
+  const varianceScore = Math.atan(variance) / (Math.PI / 2);
+
+  const formattingScore = formattingBoost / textBeads.length; // 0..1
+
+  return 0.7 * varianceScore + 0.3 * formattingScore;
+}

--- a/judge/index.ts
+++ b/judge/index.ts
@@ -1,0 +1,67 @@
+import { GameState, JudgmentScroll, JudgedScores } from "@gbg/types";
+import { evaluateAesthetics } from "./aesthetics";
+import { checkIntegrity } from "./integrity";
+
+export { evaluateAesthetics } from "./aesthetics";
+export { checkIntegrity } from "./integrity";
+
+/**
+ * Central judge pipeline combining all heuristic modules.
+ */
+export function judge(state: GameState): JudgmentScroll {
+  const scores: Record<string, JudgedScores> = {};
+  const integrity = checkIntegrity(state);
+
+  for (const p of state.players) {
+    const playerBeads = Object.values(state.beads).filter(
+      (b) => b.ownerId === p.id
+    );
+    const playerEdges = Object.values(state.edges).filter((e) => {
+      const fromOwner = state.beads[e.from]?.ownerId;
+      const toOwner = state.beads[e.to]?.ownerId;
+      return fromOwner === p.id || toOwner === p.id;
+    });
+
+    const beadCount = playerBeads.length;
+    const edgeCount = playerEdges.length;
+
+    const resonance = Math.min(
+      1,
+      (edgeCount / Math.max(1, beadCount)) * 0.6 + 0.2
+    );
+    const aesthetics = evaluateAesthetics(playerBeads);
+    const novelty = 0.4 + 0.1 * Math.tanh(beadCount / 4);
+    const flaggedEdges = playerEdges.filter((e) => integrity.flagged.includes(e.id))
+      .length;
+    const integrityScore = Math.max(
+      0,
+      1 - flaggedEdges / Math.max(1, playerEdges.length)
+    );
+    const resilience = 0.5; // placeholder for now
+    const total =
+      0.3 * resonance +
+      0.2 * novelty +
+      0.2 * integrityScore +
+      0.2 * aesthetics +
+      0.1 * resilience;
+
+    scores[p.id] = {
+      resonance,
+      aesthetics,
+      novelty,
+      integrity: integrityScore,
+      resilience,
+      total,
+    };
+  }
+
+  const winner = Object.entries(scores).sort((a, b) => b[1].total - a[1].total)[0]?.[0];
+
+  return {
+    winner,
+    scores,
+    strongPaths: [],
+    weakSpots: integrity.flagged,
+    missedFuse: undefined,
+  };
+}

--- a/judge/integrity.ts
+++ b/judge/integrity.ts
@@ -1,0 +1,44 @@
+import { GameState } from "@gbg/types";
+
+// List of keyword opposition pairs
+const oppositions: Array<[string, string]> = [
+  ["war", "peace"],
+  ["love", "hate"],
+  ["light", "dark"],
+  ["good", "evil"],
+  ["hot", "cold"],
+  ["day", "night"],
+];
+
+// Words that imply similarity; using these with opposite titles signals contradiction
+const similarityWords = ["similar", "same", "alike", "equivalent", "analogous", "akin"];
+
+export interface IntegrityResult {
+  flagged: string[]; // edge ids that appear contradictory
+}
+
+/**
+ * Examine binds in the game state and flag those whose justification claims
+ * similarity between beads with obviously opposing titles.  Uses a small list
+ * of keyword opposition pairs for the detection.
+ */
+export function checkIntegrity(state: GameState): IntegrityResult {
+  const flagged: string[] = [];
+  for (const edge of Object.values(state.edges)) {
+    const fromTitle = state.beads[edge.from]?.title?.toLowerCase() ?? "";
+    const toTitle = state.beads[edge.to]?.title?.toLowerCase() ?? "";
+    const just = edge.justification.toLowerCase();
+
+    if (!similarityWords.some((w) => just.includes(w))) continue;
+
+    for (const [a, b] of oppositions) {
+      const cond1 = fromTitle.includes(a) && toTitle.includes(b);
+      const cond2 = fromTitle.includes(b) && toTitle.includes(a);
+      if (cond1 || cond2) {
+        flagged.push(edge.id);
+        break;
+      }
+    }
+  }
+  return { flagged };
+}


### PR DESCRIPTION
## Summary
- Resolve merge conflict in server entrypoint by importing `JudgmentScroll` and using the existing judge pipeline
- Introduce heuristic modules (`checkIntegrity`, `evaluateAesthetics`) and central judge pipeline
- Add tests validating heuristics and judge integration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `npx tsx --test apps/server/test/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf45c62aac832c8d3d73bf01a6b0af