### PR TITLE
Refactor server routes and add realtime test

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -41,13 +41,14 @@ function broadcast(matchId: string, type: string, payload: any){
 }
 
 function scheduleUpdate(matchId: string, state: GameState, move?: Move){
+  const snapshot = JSON.parse(JSON.stringify(state));
   const start = now();
   let sent = false;
   const send = () => {
     if(sent) return;
     sent = true;
     if(move) broadcast(matchId, "move:accepted", move);
-    broadcast(matchId, "state:update", state);
+    broadcast(matchId, "state:update", snapshot);
     const latency = now() - start;
     console.log("[latency]", { matchId, latency });
   };


### PR DESCRIPTION
## Summary
- clone match state before scheduling deferred websocket broadcast to preserve request ordering

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `for f in apps/server/test/*.test.ts; do npx tsx --test "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68bf466b5a18832c99f625fc60ca562c