### PR TITLE
fix: filter invalid moves from exported logs

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -155,8 +155,6 @@ fastify.post<{ Params: { id: string } }>("/match/:id/move", async (req, reply) =
   }
   if(!validateMove(move, state)){
     move.valid = false;
-    state.moves.push(move);
-    state.updatedAt = move.timestamp;
     return reply.code(400).send({ error: "Invalid move" });
   }
   move.valid = true;

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -18,5 +18,6 @@ export function replayMoves(log: GameState): GameState {
     moves: [],
     updatedAt: log.createdAt,
   };
-  return replayLib(initial, log.moves);
+  const moves = log.moves.filter((m) => m.valid !== false);
+  return replayLib(initial, moves);
 }


### PR DESCRIPTION
## Summary
- avoid recording invalid moves so match exports stay replayable
- skip invalid entries when reconstructing a game from a log

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test --import tsx apps/server/test/cast.test.ts`
- `node --test --import tsx apps/server/test/match.test.ts`
- `node --test --import tsx apps/server/test/replay.test.ts`
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf45f83bbc832cb296b06199fe025c