### PR TITLE
Resolve merge conflicts for resonance path analysis

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Notes
+
+## Resonance Path Analysis
+
+The **Magister Ludi** judge scores resonance by inspecting the game graph.
+Each bead becomes a node weighted by its complexity and each bind becomes a
+unit‑weight edge. Using this graph we compute the top weighted paths:
+
+1. `findStrongestPaths` explores all simple paths and sums node and edge weights.
+2. The three heaviest paths are kept as `strongPaths` for the `JudgmentScroll`.
+3. Resonance is proportional to the strongest path weight (clamped to 0‑1).
+
+This simple heuristic highlights long, coherent chains of ideas while remaining
+deterministic and easy to explain.

--- a/judge/resonance.ts
+++ b/judge/resonance.ts
@@ -1,0 +1,47 @@
+import {
+  GameState,
+  JudgmentScroll,
+  JudgedScores,
+  GraphState,
+  findStrongestPaths,
+  addBead,
+  addEdge,
+} from "../packages/types/src/index.ts";
+
+function toGraph(state: GameState): GraphState {
+  const graph: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  for (const bead of Object.values(state.beads)) {
+    addBead(graph, bead);
+  }
+  for (const edge of Object.values(state.edges)) {
+    addEdge(graph, edge);
+  }
+  return graph;
+}
+
+export function judgeResonance(state: GameState): JudgmentScroll {
+  const graph = toGraph(state);
+  const strong = findStrongestPaths(graph, 3);
+  const topWeight = strong[0]?.weight ?? 0;
+  const resonance = Math.min(1, topWeight / 10);
+  const scores: Record<string, JudgedScores> = {};
+  for (const p of state.players) {
+    const total = resonance; // other axes omitted in this sample
+    scores[p.id] = {
+      resonance,
+      aesthetics: 0,
+      novelty: 0,
+      integrity: 0,
+      resilience: 0,
+      total,
+    };
+  }
+  const winner = Object.entries(scores).sort((a, b) => b[1].total - a[1].total)[0]?.[0];
+  return {
+    winner,
+    scores,
+    strongPaths: strong.map((p) => ({ nodes: p.nodes, why: `weight=${p.weight.toFixed(2)}` })),
+    weakSpots: [],
+    missedFuse: undefined,
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 import sanitizeHtml from "sanitize-html";
+export * from "./graph";
 
 export type Modality = "text" | "image" | "audio" | "math" | "code" | "data";
 export type RelationLabel =

--- a/packages/types/test/resonance.test.ts
+++ b/packages/types/test/resonance.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GraphState, addBead, addEdge, findStrongestPaths, GameState } from "../src/index.ts";
+import { judgeResonance } from "../../../judge/resonance.ts";
+
+test("findStrongestPaths returns heaviest paths", () => {
+  const graph: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const a = { id: "a", ownerId: "p", modality: "text", content: "", complexity: 1, createdAt: 0 };
+  const b = { id: "b", ownerId: "p", modality: "text", content: "", complexity: 2, createdAt: 0 };
+  const c = { id: "c", ownerId: "p", modality: "text", content: "", complexity: 3, createdAt: 0 };
+  addBead(graph, a);
+  addBead(graph, b);
+  addBead(graph, c);
+  addEdge(graph, { id: "e1", from: "a", to: "b", label: "analogy", justification: "" });
+  addEdge(graph, { id: "e2", from: "b", to: "c", label: "analogy", justification: "" });
+  const paths = findStrongestPaths(graph, 2);
+  assert.equal(paths[0].nodes.join(""), "abc");
+  assert.ok(paths[0].weight > (paths[1]?.weight ?? -Infinity));
+});
+
+test("judgeResonance populates strongPaths", () => {
+  const state: GameState = {
+    id: "m1",
+    round: 1,
+    phase: "Play",
+    players: [{ id: "p1", handle: "A", resources: { insight: 5, restraint: 2, wildAvailable: true } }],
+    seeds: [],
+    beads: {
+      a: { id: "a", ownerId: "p1", modality: "text", content: "A", complexity: 1, createdAt: 0 },
+      b: { id: "b", ownerId: "p1", modality: "text", content: "B", complexity: 2, createdAt: 0 },
+      c: { id: "c", ownerId: "p1", modality: "text", content: "C", complexity: 3, createdAt: 0 },
+    },
+    edges: {
+      e1: { id: "e1", from: "a", to: "b", label: "analogy", justification: "" },
+      e2: { id: "e2", from: "b", to: "c", label: "analogy", justification: "" },
+    },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+  const scroll = judgeResonance(state);
+  assert.equal(scroll.strongPaths[0].nodes.join(""), "abc");
+  assert.ok(scroll.scores["p1"].resonance > 0);
+});


### PR DESCRIPTION
## Summary
- merge latest `main` into `codex/add-findstrongestpaths-function`
- adapt graph utilities to new bead/edge structure with `findStrongestPaths`
- update resonance judge and tests for new graph state

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf48888804832c8d1f3c9b173ba334