### PR TITLE
Fix: include judge module in server build

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,7 @@ import {
   validateMove,
   sanitizeMarkdown,
 } from "@gbg/types";
-import { judge } from "./judge";
+import { judge } from "./judge/index.js";
 
 const fastify = Fastify({ logger: false });
 await fastify.register(cors, { origin: true });

--- a/apps/server/test/heuristics.test.ts
+++ b/apps/server/test/heuristics.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { checkIntegrity } from '../src/judge/integrity';
 import { evaluateAesthetics } from '../src/judge/aesthetics';
-import { judge } from '../src/judge';
+import { judge } from '../src/judge/index.js';
 import { GameState, Bead, Edge } from '@gbg/types';
 
 function sampleState(): GameState {


### PR DESCRIPTION
## Summary
- move judge heuristics into the server package
- update imports to reference the new module
- reference the judge entry file explicitly to avoid directory imports

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `npm --workspace apps/server run typecheck`
- `node --import tsx --test apps/server/test/heuristics.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf4786b8d0832c812069faf9257d28