### PR TITLE
feat: add twist enforcement and counterpoint move

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -117,15 +117,9 @@ export function validateMove(move: Move, state: GameState): boolean {
   if (!move || !state) return false;
 
   const twist = state.twist?.effect;
-  if (twist) {
-    if (twist.modalityLock && move.type === "cast") {
-      const bead = move.payload?.bead as Bead | undefined;
-      if (!bead || !twist.modalityLock.includes(bead.modality)) return false;
-    }
-    if (twist.requiredRelation && move.type === "bind") {
-      const { label } = move.payload ?? {};
-      if (label !== twist.requiredRelation) return false;
-    }
+  if (twist?.modalityLock && move.type === "cast") {
+    const bead = move.payload?.bead as Bead | undefined;
+    if (!bead || !twist.modalityLock.includes(bead.modality)) return false;
   }
 
   if (move.type === "cast") {
@@ -150,7 +144,8 @@ export function validateMove(move: Move, state: GameState): boolean {
     const { from, to, label, justification } = move.payload ?? {};
     if (!from || !to || from === to) return false;
     if (!state.beads[from] || !state.beads[to]) return false;
-    if (label !== "analogy") return false;
+    const expectedLabel = twist?.requiredRelation ?? "analogy";
+    if (label !== expectedLabel) return false;
     if (typeof justification !== "string" || justification.trim().length === 0)
       return false;
     const cleanJust = sanitizeMarkdown(justification);

--- a/packages/types/test/validateMove.test.ts
+++ b/packages/types/test/validateMove.test.ts
@@ -58,6 +58,27 @@ test('bind respects required relation from twist', () => {
   assert.equal(validateMove(move, state), false);
 });
 
+test('bind satisfies required relation from twist', () => {
+  const state: GameState = {
+    ...baseState,
+    beads: {
+      a: { id: 'a', ownerId: 'p1', modality: 'text', content: 'A', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p2', modality: 'text', content: 'B', complexity: 1, createdAt: 0 },
+    },
+    twist: { id: 't', name: 'causality only', description: '', effect: { requiredRelation: 'causality' } },
+  };
+  const move: Move = {
+    id: 'm2',
+    playerId: 'p1',
+    type: 'bind',
+    payload: { from: 'a', to: 'b', label: 'causality', justification: 'First. Second.' },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(move, state), true);
+});
+
 test('counterpoint references opponent bead', () => {
   const state: GameState = {
     ...baseState,


### PR DESCRIPTION
## Summary
- extend move types with `counterpoint` and enforce twist constraints in `validateMove`
- stub counterpoint apply logic and add tests for twist and counterpoint validation
- document twist enforcement and counterpoint as beta features in PRD
- use twist's `requiredRelation` when validating bind moves

## Testing
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf49057fe4832c8420b5207df5e138