### PR TITLE
fix: import novelty scorer without build

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,10 +15,8 @@ import {
   validateMove,
   sanitizeMarkdown,
 } from "@gbg/types";
-import { createRequire } from "module";
-
-const require = createRequire(import.meta.url);
-const { scoreNovelty } = require("../../judge/novelty.js") as {
+// @ts-ignore - import TypeScript module without build step
+const { scoreNovelty } = await import("../../../judge/novelty.ts") as {
   scoreNovelty: (state: GameState) => Record<string, number>;
 };
 

--- a/apps/server/src/novelty.d.ts
+++ b/apps/server/src/novelty.d.ts
@@ -1,4 +1,0 @@
-declare module "../../judge/novelty" {
-  import type { GameState } from "@gbg/types";
-  export function scoreNovelty(state: GameState): Record<string, number>;
-}


### PR DESCRIPTION
## Summary
- dynamically import novelty scorer from TS source to avoid missing JS build
- drop obsolete type declaration

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run typecheck`
- `node --test --import tsx apps/server/test/novelty.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf48c39490832cb93e5faab0896602