### PR TITLE
fix: support built server novelty import

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,10 +15,23 @@ import {
   validateMove,
   sanitizeMarkdown,
 } from "@gbg/types";
-// @ts-ignore - import TypeScript module without build step
-const { scoreNovelty } = await import("../../../judge/novelty.ts") as {
-  scoreNovelty: (state: GameState) => Record<string, number>;
-};
+
+let scoreNovelty: (state: GameState) => Record<string, number>;
+try {
+  // @ts-ignore - import JavaScript module outside rootDir
+  ({ scoreNovelty } = await import("../../../judge/novelty.js") as {
+    scoreNovelty: typeof scoreNovelty;
+  });
+} catch (err: any) {
+  if (err.code === "ERR_MODULE_NOT_FOUND" || err.code === "MODULE_NOT_FOUND") {
+    // @ts-ignore - import TypeScript module without build step
+    ({ scoreNovelty } = await import("../../../judge/novelty.ts") as {
+      scoreNovelty: typeof scoreNovelty;
+    });
+  } else {
+    throw err;
+  }
+}
 
 const fastify = Fastify({ logger: false });
 await fastify.register(cors, { origin: true });


### PR DESCRIPTION
## Summary
- try loading built `novelty.js` first and fall back to TypeScript source
- ignore type-checking for out-of-tree imports

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run typecheck`
- `node --test --import tsx apps/server/test/novelty.test.ts`
- `npm --workspace apps/server run build`
- `node apps/server/dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf4b458558832cb0dd0c10a49b4ec8