### PR TITLE
Increase test server startup delays

### DIFF
--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -19,7 +19,7 @@ function startServer(port: number){
 test('cast rejects when insight and wild exhausted', async (t) => {
   const port = 9997;
   const server = startServer(port);
-  await new Promise(r => setTimeout(r, 500));
+  await new Promise(r => setTimeout(r, 1000));
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 
@@ -83,7 +83,7 @@ test('cast rejects when insight and wild exhausted', async (t) => {
 test('bind uses restraint then wild then rejects', async (t) => {
   const port = 9996;
   const server = startServer(port);
-  await new Promise(r => setTimeout(r, 500));
+  await new Promise(r => setTimeout(r, 1000));
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 


### PR DESCRIPTION
## Summary
- ensure server startup waits use 1s delay across move tests

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `npx --yes tsx --test apps/server/test/*.test.ts` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4db01a8c832c9b97a329635c6859