### PR TITLE
feat: simplify bead payload

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -84,7 +84,7 @@ export default function App() {
       ownerId: playerId,
       modality: "text",
       title: "Idea",
-      content: JSON.stringify({ markdown: text }),
+      content: text,
       complexity: 1,
       createdAt: Date.now(),
       seedId: state.seeds[0]?.id
@@ -268,10 +268,5 @@ export default function App() {
 }
 
 function tryParseMarkdown(content: string){
-  try{
-    const obj = JSON.parse(content);
-    return obj.markdown || content;
-  }catch{
-    return content;
-  }
+  return content;
 }


### PR DESCRIPTION
## Summary
- send bead content as plain string when casting
- remove JSON parsing from bead renderer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`
- `npm --workspace packages/types test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4fe6f488832cb6f01d38c75dee14