### PR TITLE
Handle websocket send failures by pruning sockets

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -40,7 +40,14 @@ function broadcast(matchId: string, type: string, payload: any){
     }catch(err){
       metrics.wsSendFailures++;
       console.warn('WS send failed', err, { wsSendFailures: metrics.wsSendFailures });
+      try{
+        ws.close();
+      }catch{}
+      set.delete(ws);
     }
+  }
+  if(set.size === 0){
+    sockets.delete(matchId);
   }
 }
 


### PR DESCRIPTION
## Summary
- Close and remove WebSockets that throw during send
- Drop match entry when no sockets remain

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf4fecd934832cad352033403f16c3