### PR TITLE
feat(server): centralize metrics tracking

### DIFF
--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance } from "fastify";
+import {
+  Bead,
+  GameState,
+  Move,
+  applyMoveWithResources,
+  sanitizeMarkdown,
+  validateMove,
+} from "@gbg/types";
+
+interface MoveDeps {
+  matches: Map<string, GameState>;
+  broadcast: (matchId: string, type: string, payload: any) => void;
+  now: () => number;
+  logMetrics: (matchId: string, move: Move, state: GameState) => void;
+}
+
+export default function registerMoveRoute(
+  fastify: FastifyInstance,
+  deps: MoveDeps
+) {
+  const { matches, broadcast, now, logMetrics } = deps;
+
+  fastify.post<{ Params: { id: string } }>(
+    "/match/:id/move",
+    async (req, reply) => {
+      const id = req.params.id;
+      const state = matches.get(id);
+      if (!state)
+        return reply.code(404).send({ error: "No such match" });
+
+      const move = (req.body as any) as Move;
+      // sanitize text fields
+      if (move.type === "cast") {
+        const bead = move.payload?.bead as Bead;
+        if (bead) {
+          bead.content = sanitizeMarkdown(bead.content);
+          if (typeof bead.title === "string") {
+            bead.title = sanitizeMarkdown(bead.title);
+          }
+        }
+      } else if (move.type === "bind") {
+        if (typeof move.payload?.justification === "string") {
+          move.payload.justification = sanitizeMarkdown(
+            move.payload.justification
+          );
+        }
+      }
+      const validation = validateMove(move, state);
+      if (!validation.ok) {
+        return reply.code(400).send({ error: validation.error });
+      }
+      move.valid = true;
+      applyMoveWithResources(state, move);
+      state.updatedAt = now();
+      const idx = state.players.findIndex((p) => p.id === move.playerId);
+      if (idx >= 0 && state.players.length > 0) {
+        const next = state.players[(idx + 1) % state.players.length];
+        state.currentPlayerId = next.id;
+      }
+      broadcast(id, "move:accepted", move);
+      broadcast(id, "state:update", state);
+      logMetrics(id, move, state);
+      return reply.send({ ok: true });
+    }
+  );
+}

--- a/apps/server/test/metrics.test.ts
+++ b/apps/server/test/metrics.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('metrics endpoint reports move counts and latency', async (t) => {
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: '9997' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  await new Promise(res => setTimeout(res, 1000));
+  t.after(() => {
+    server.kill();
+  });
+
+  const base = 'http://127.0.0.1:9997';
+
+  const matchRes = await fetch(`${base}/match`, { method: 'POST' });
+  const match = await matchRes.json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+  await join('Bob');
+
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2,8)}`,
+    ownerId: p1.id,
+    modality: 'text',
+    content: 'idea',
+    complexity: 1,
+    createdAt: Date.now()
+  };
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2,8)}`,
+    playerId: p1.id,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+  await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+
+  const metricsRes = await fetch(`${base}/metrics`);
+  const data = await metricsRes.json();
+
+  assert.equal(data.totalMoves, 1);
+  assert.equal(data.wsSendFailures, 0);
+  assert.ok(typeof data.latency === 'number' && data.latency > 0);
+});

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -19,7 +19,7 @@ function startServer(port: number){
 test('cast rejects when insight and wild exhausted', async (t) => {
   const port = 9997;
   const server = startServer(port);
-  await new Promise(r => setTimeout(r, 500));
+  await new Promise(r => setTimeout(r, 1000));
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 
@@ -83,7 +83,7 @@ test('cast rejects when insight and wild exhausted', async (t) => {
 test('bind uses restraint then wild then rejects', async (t) => {
   const port = 9996;
   const server = startServer(port);
-  await new Promise(r => setTimeout(r, 500));
+  await new Promise(r => setTimeout(r, 1000));
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -84,7 +84,7 @@ export default function App() {
       ownerId: playerId,
       modality: "text",
       title: "Idea",
-      content: JSON.stringify({ markdown: text }),
+      content: text,
       complexity: 1,
       createdAt: Date.now(),
       seedId: state.seeds[0]?.id
@@ -268,10 +268,5 @@ export default function App() {
 }
 
 function tryParseMarkdown(content: string){
-  try{
-    const obj = JSON.parse(content);
-    return obj.markdown || content;
-  }catch{
-    return content;
-  }
+  return content;
 }

--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -2,6 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
 import type { GameState } from "@gbg/types";
 
+interface Node extends d3.SimulationNodeDatum {
+  id: string;
+}
+
+interface Link extends d3.SimulationLinkDatum<Node> {
+  id: string;
+}
+
 export interface GraphViewProps {
   /** Match id to connect to websocket and receive live state */
   matchId?: string;
@@ -44,14 +52,20 @@ export default function GraphView({
   // Render graph using d3 whenever state or selection changes
   useEffect(() => {
     if (!state) return;
-    const nodes: Array<d3.SimulationNodeDatum & { id: string }> = Object.values(
-      state.beads
-    ).map((b) => ({ id: b.id }));
-    const links: Array<d3.SimulationLinkDatum<d3.SimulationNodeDatum> & { id: string }> = Object.values(
-      state.edges
-    ).map((e) => ({ id: e.id, source: e.from, target: e.to }));
+    const nodes: Node[] = Object.values(state.beads).map((b) => ({ id: b.id }));
+    const links: Link[] = Object.values(state.edges).map((e) => ({
+      id: e.id,
+      source: e.from,
+      target: e.to,
+    }));
 
-    const svg = d3.select(svgRef.current) as any;
+    const simulation = d3
+      .forceSimulation<Node>(nodes)
+      .force("link", d3.forceLink<Node, Link>(links).id((d) => d.id))
+      .force("charge", d3.forceManyBody<Node>().strength(-200))
+      .force("center", d3.forceCenter(width / 2, height / 2));
+
+    const svg = d3.select<SVGSVGElement, unknown>(svgRef.current!);
     svg.selectAll("*").remove();
     svg.attr("viewBox", `0 0 ${width} ${height}`);
 
@@ -61,71 +75,60 @@ export default function GraphView({
       .append("g")
       .attr("stroke", "#888")
       .attr("stroke-width", 1.5)
-      .selectAll("line")
+      .selectAll<SVGLineElement, Link>("line")
       .data(links)
       .enter()
       .append("line")
-      .attr("id", (d: any) => d.id);
+      .attr("id", (d) => d.id);
 
     const node = g
       .append("g")
       .attr("stroke", "#fff")
       .attr("stroke-width", 1.5)
-      .selectAll("circle")
+      .selectAll<SVGCircleElement, Node>("circle")
       .data(nodes)
       .enter()
       .append("circle")
       .attr("r", 10)
       .attr("fill", "#4f46e5");
 
-    (node as any).call(
-      d3
-        .drag<SVGCircleElement, d3.SimulationNodeDatum>()
-        .on("start", (event: any, d: any) => {
-          if (!event.active) simulation.alphaTarget(0.3).restart();
-          d.fx = d.x;
-          d.fy = d.y;
-        })
-        .on("drag", (event: any, d: any) => {
-          d.fx = event.x;
-          d.fy = event.y;
-        })
-        .on("end", (event: any, d: any) => {
-          if (!event.active) simulation.alphaTarget(0);
-          d.fx = null;
-          d.fy = null;
-        })
-    );
+    const drag = d3
+      .drag<SVGCircleElement, Node>()
+      .on("start", (event, d) => {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        d.fx = d.x;
+        d.fy = d.y;
+      })
+      .on("drag", (event, d) => {
+        d.fx = event.x;
+        d.fy = event.y;
+      })
+      .on("end", (event, d) => {
+        if (!event.active) simulation.alphaTarget(0);
+        d.fx = null;
+        d.fy = null;
+      });
 
-    const simulation = d3
-      .forceSimulation(nodes)
-      .force(
-        "link",
-        d3.forceLink(links).id((d: any) => d.id)
-      )
-      .force("charge", d3.forceManyBody().strength(-200))
-      .force("center", d3.forceCenter(width / 2, height / 2));
+    node.call(drag);
 
     simulation.on("tick", () => {
       link
-        .attr("x1", (d: any) => (d.source as any).x)
-        .attr("y1", (d: any) => (d.source as any).y)
-        .attr("x2", (d: any) => (d.target as any).x)
-        .attr("y2", (d: any) => (d.target as any).y);
-      node.attr("cx", (d: any) => d.x).attr("cy", (d: any) => d.y);
+        .attr("x1", (d) => (d.source as Node).x ?? 0)
+        .attr("y1", (d) => (d.source as Node).y ?? 0)
+        .attr("x2", (d) => (d.target as Node).x ?? 0)
+        .attr("y2", (d) => (d.target as Node).y ?? 0);
+      node.attr("cx", (d) => d.x ?? 0).attr("cy", (d) => d.y ?? 0);
     });
 
-    // zoom + pan
-    (svg as any).call(
+    svg.call(
       d3
         .zoom<SVGSVGElement, unknown>()
         .scaleExtent([0.1, 4])
-        .on("zoom", (event: any) => {
-          g.attr("transform", event.transform);
+        .on("zoom", (event) => {
+          g.attr("transform", event.transform.toString());
         })
     );
 
-    // Highlight selected path
     if (strongPaths && selectedPathIndex !== undefined) {
       const path = strongPaths[selectedPathIndex]?.nodes ?? [];
       const nodeSet = new Set(path);
@@ -133,15 +136,15 @@ export default function GraphView({
       for (let i = 0; i < path.length - 1; i++) {
         edgeSet.add(`${path[i]}|${path[i + 1]}`);
       }
-      node.attr("fill", (d: any) => (nodeSet.has(d.id) ? "#ef4444" : "#4f46e5"));
+      const getId = (n: string | number | Node) =>
+        typeof n === "string" || typeof n === "number" ? String(n) : n.id;
+      node.attr("fill", (d) => (nodeSet.has(d.id) ? "#ef4444" : "#4f46e5"));
       link
-        .attr("stroke", (d: any) =>
-          edgeSet.has(`${d.source.id || d.source}|${d.target.id || d.target}`)
-            ? "#ef4444"
-            : "#888"
+        .attr("stroke", (d) =>
+          edgeSet.has(`${getId(d.source)}|${getId(d.target)}`) ? "#ef4444" : "#888"
         )
-        .attr("stroke-width", (d: any) =>
-          edgeSet.has(`${d.source.id || d.source}|${d.target.id || d.target}`) ? 3 : 1.5
+        .attr("stroke-width", (d) =>
+          edgeSet.has(`${getId(d.source)}|${getId(d.target)}`) ? 3 : 1.5
         );
     }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,4 @@
 import sanitizeHtml from "sanitize-html";
-export * from "./graph";
 
 export type Modality = "text" | "image" | "audio" | "math" | "code" | "data";
 export type RelationLabel =


### PR DESCRIPTION
## Summary
- merge main and resolve server metrics conflicts
- route registration now uses shared metrics helpers and cleans up failed sockets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf530948ac832c8bf848d117fe9096