### PR TITLE
Set current player on join and broadcast state

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -72,7 +72,7 @@ fastify.post("/match", async (req, reply) => {
   return reply.send(state);
 });
 
-registerJoinRoute(fastify, matches, broadcast);
+registerJoinRoute(fastify, matches, broadcast, now);
 
 fastify.get<{ Params: { id: string } }>("/match/:id", async (req, reply) => {
   const state = matches.get(req.params.id);

--- a/apps/server/src/routes/join.ts
+++ b/apps/server/src/routes/join.ts
@@ -12,7 +12,8 @@ type BroadcastFn = (id: string, type: string, payload: any) => void;
 export default function registerJoinRoute(
   fastify: FastifyInstance,
   matches: Map<string, GameState>,
-  broadcast: BroadcastFn
+  broadcast: BroadcastFn,
+  now: () => number,
 ){
   fastify.post<{ Params: { id: string } }>("/match/:id/join", async (req, reply) => {
     const id = req.params.id;
@@ -29,7 +30,7 @@ export default function registerJoinRoute(
     if(state.currentPlayerId === undefined){
       state.currentPlayerId = player.id;
     }
-    state.updatedAt = Date.now();
+    state.updatedAt = now();
     broadcast(id, "state:update", state);
     return reply.send(player);
   });


### PR DESCRIPTION
## Summary
- move join logic into dedicated route that sets the initial `currentPlayerId`
- broadcast updated match state to clients when a player joins
- fix types package export to use explicit file extension
- inject time function into join route to set `updatedAt`

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --import tsx --test test/*.test.ts` *(fails: Could not find '/workspace/glass-bead-game/test/*.test.ts')*
- `node --import tsx --test packages/types/test/*.test.ts`
- `node --import tsx --test apps/server/test/*.test.ts` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_68bf538f635c832ca0f69ce34fa89c64