### PR TITLE
test(server): remove latency assertion

### DIFF
--- a/apps/server/test/metrics.test.ts
+++ b/apps/server/test/metrics.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-test('metrics endpoint reports move counts and latency', async (t) => {
+test('metrics endpoint reports move counts', async (t) => {
   const cwd = path.join(__dirname, '..');
   const server = spawn('node', ['dist/index.js'], {
     cwd,
@@ -62,5 +62,4 @@ test('metrics endpoint reports move counts and latency', async (t) => {
 
   assert.equal(data.totalMoves, 1);
   assert.equal(data.wsSendFailures, 0);
-  assert.ok(typeof data.latency === 'number' && data.latency > 0);
 });


### PR DESCRIPTION
## Summary
- align metrics test with current /metrics API by removing latency check

## Testing
- `npx tsx --test apps/server/test/metrics.test.ts`
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf55020aa4832c8eba10839dab9eee