### PR TITLE
test: assign unique ports for server tests

### DIFF
--- a/apps/server/test/metrics.test.ts
+++ b/apps/server/test/metrics.test.ts
@@ -8,9 +8,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('metrics endpoint reports move counts and latency', async (t) => {
   const cwd = path.join(__dirname, '..');
+  const port = 9995;
   const server = spawn('node', ['dist/index.js'], {
     cwd,
-    env: { ...process.env, PORT: '9997' },
+    env: { ...process.env, PORT: String(port) },
     stdio: ['ignore', 'pipe', 'pipe']
   });
   await new Promise(res => setTimeout(res, 1000));
@@ -18,7 +19,7 @@ test('metrics endpoint reports move counts and latency', async (t) => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9997';
+  const base = `http://127.0.0.1:${port}`;
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -8,9 +8,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('turn switches to next player after move', async (t) => {
   const cwd = path.join(__dirname, '..');
+  const port = 9994;
   const server = spawn('node', ['dist/index.js'], {
     cwd,
-    env: { ...process.env, PORT: '9997' },
+    env: { ...process.env, PORT: String(port) },
     stdio: ['ignore', 'pipe', 'pipe']
   });
   await new Promise(res => setTimeout(res, 1000));
@@ -18,7 +19,7 @@ test('turn switches to next player after move', async (t) => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9997';
+  const base = `http://127.0.0.1:${port}`;
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();


### PR DESCRIPTION
## Summary
- use dedicated ports in metrics and turn tests to avoid conflicts during parallel runs

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test apps/server/test/*.test.ts` *(fails: Unknown file extension ".ts" for test files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf55284a20832cb674949202486104