### PR TITLE
Add resilience scoring with perturbation analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ NLI contradiction checks for Integrity, and shingle/LSH rarity for Novelty.
 
 ## Architecture
 ![Architecture Diagram](docs/architecture.svg)
+
+## Additional Documentation
+See [docs/](docs/README.md) for the project vision, product requirements, and development plan.

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,34 @@
+# Server
+
+Backend for the Glass Bead Game built with Fastify and WebSockets. The server
+maintains in‑memory matches, validates moves via `@gbg/types` helpers and emits
+state updates to connected clients.
+
+## REST endpoints
+
+- `POST /match` – create a new match and return its initial state
+- `POST /match/:id/join` – join an existing match with a handle
+- `GET /match/:id` – fetch current match state
+- `POST /match/:id/move` – submit a move; broadcast on acceptance
+- `POST /match/:id/judge` – run the stub judge and broadcast results
+- `GET /match/:id/log` – download the entire match state as JSON
+
+WebSocket connections are upgraded at `ws://localhost:8787/?matchId=ID` and
+receive `state:update` and `move:accepted` events.
+
+## Development
+
+From the repository root you can use workspace scripts:
+
+```bash
+# Start the server in watch mode on http://localhost:8787
+npm --workspace apps/server run dev
+
+# Build the compiled output to dist/
+npm --workspace apps/server run build
+
+# Type‑check without emitting output
+npm --workspace apps/server run typecheck
+```
+
+The server stores everything in memory; restarting clears active matches.

--- a/apps/server/src/judge/aesthetics.ts
+++ b/apps/server/src/judge/aesthetics.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount }: { beadCount: number }): number {
+  return Math.min(1, beadCount > 0 ? 0.3 + 0.05 * beadCount : 0.2);
+}

--- a/apps/server/src/judge/index.ts
+++ b/apps/server/src/judge/index.ts
@@ -1,0 +1,41 @@
+import { GameState, JudgedScores, JudgmentScroll } from '@gbg/types';
+import { score as resonance } from './resonance.js';
+import { score as novelty } from './novelty.js';
+import { score as integrity } from './integrity.js';
+import { score as aesthetics } from './aesthetics.js';
+import { evaluateResilience, mulberry32 } from './resilience.js';
+
+const WEIGHTS = {
+  resonance: 0.30,
+  novelty: 0.20,
+  integrity: 0.20,
+  aesthetics: 0.20,
+  resilience: 0.10,
+} as const;
+
+export function judge(state: GameState): JudgmentScroll {
+  const scores: Record<string, JudgedScores> = {};
+  const res = evaluateResilience(state, 5, mulberry32(42));
+
+  for (const p of state.players) {
+    const beadCount = Object.values(state.beads).filter(b => b.ownerId === p.id).length;
+    const edgeCount = Object.values(state.edges).filter(e => {
+      const owns = state.beads[e.from]?.ownerId === p.id || state.beads[e.to]?.ownerId === p.id;
+      return owns;
+    }).length;
+    const slice = { beadCount, edgeCount };
+    const r = resonance(slice);
+    const n = novelty(slice);
+    const i = integrity(slice);
+    const a = aesthetics(slice);
+    const rs = res.scores[p.id] ?? 1;
+    const total = WEIGHTS.resonance * r + WEIGHTS.novelty * n +
+      WEIGHTS.integrity * i + WEIGHTS.aesthetics * a + WEIGHTS.resilience * rs;
+    scores[p.id] = { resonance: r, novelty: n, integrity: i, aesthetics: a, resilience: rs, total };
+  }
+
+  const winner = Object.entries(scores).sort((a, b) => b[1].total - a[1].total)[0]?.[0];
+  return { winner, scores, strongPaths: [], weakSpots: res.weakSpots, missedFuse: undefined };
+}
+
+export default judge;

--- a/apps/server/src/judge/integrity.ts
+++ b/apps/server/src/judge/integrity.ts
@@ -1,0 +1,3 @@
+export function score({ edgeCount }: { edgeCount: number }): number {
+  return 0.5 + 0.1 * Math.tanh(edgeCount / 5);
+}

--- a/apps/server/src/judge/novelty.ts
+++ b/apps/server/src/judge/novelty.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount }: { beadCount: number }): number {
+  return 0.4 + 0.1 * Math.tanh(beadCount / 4);
+}

--- a/apps/server/src/judge/resilience.ts
+++ b/apps/server/src/judge/resilience.ts
@@ -8,7 +8,7 @@ export interface ResilienceResult {
 function mulberry32(seed: number): () => number {
   let t = seed >>> 0;
   return () => {
-    t += 0x6D2B79F5;
+    t += 0x6d2b79f5;
     let r = Math.imul(t ^ (t >>> 15), t | 1);
     r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
     return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
@@ -49,14 +49,14 @@ export function evaluateResilience(
   const players = state.players.map(p => p.id);
   const baseline = scoreTotals(state);
   const drops: Record<string, number> = Object.fromEntries(
-    players.map((id) => [id, 0] as [string, number])
+    players.map(id => [id, 0] as [string, number])
   );
   const weakImpact: Record<string, number> = {};
   const edges = Object.values<Edge>(state.edges);
 
   if (edges.length === 0) {
     return {
-      scores: Object.fromEntries(players.map((id) => [id, 1] as [string, number])),
+      scores: Object.fromEntries(players.map(id => [id, 1] as [string, number])),
       weakSpots: [],
     };
   }

--- a/apps/server/src/judge/resonance.ts
+++ b/apps/server/src/judge/resonance.ts
@@ -1,0 +1,3 @@
+export function score({ beadCount, edgeCount }: { beadCount: number; edgeCount: number }): number {
+  return Math.min(1, (edgeCount / Math.max(1, beadCount)) * 0.6 + 0.2);
+}

--- a/apps/server/test/cast.test.ts
+++ b/apps/server/test/cast.test.ts
@@ -33,12 +33,12 @@ test('cast move broadcasts new bead to all players', async (t) => {
     env: { ...process.env, PORT: '9999' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  await new Promise(res => setTimeout(res, 500));
+  await new Promise(res => setTimeout(res, 1000));
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://localhost:9999';
+  const base = 'http://127.0.0.1:9999';
 
   // create match
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
@@ -57,8 +57,8 @@ test('cast move broadcasts new bead to all players', async (t) => {
   await join('B');
 
   // open websockets for both players
-  const ws1 = new WebSocket(`ws://localhost:9999/?matchId=${matchId}`);
-  const ws2 = new WebSocket(`ws://localhost:9999/?matchId=${matchId}`);
+  const ws1 = new WebSocket(`ws://127.0.0.1:9999/?matchId=${matchId}`);
+  const ws2 = new WebSocket(`ws://127.0.0.1:9999/?matchId=${matchId}`);
   const initial1 = waitForMessage(ws1, 'state:update');
   const initial2 = waitForMessage(ws2, 'state:update');
   await Promise.all([

--- a/apps/server/test/judge.test.ts
+++ b/apps/server/test/judge.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import judge from '../src/judge/index.ts';
+import { GameState } from '@gbg/types';
+
+test('judge produces deterministic scores and winner', () => {
+  const state: GameState = {
+    id: 'm1',
+    round: 1,
+    phase: 'play',
+    players: [
+      { id: 'p1', handle: 'A', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+      { id: 'p2', handle: 'B', resources: { insight: 0, restraint: 0, wildAvailable: false } }
+    ],
+    seeds: [],
+    beads: {
+      b1: { id: 'b1', ownerId: 'p1', modality: 'text', content: 'b1', complexity: 1, createdAt: 0 },
+      b2: { id: 'b2', ownerId: 'p1', modality: 'text', content: 'b2', complexity: 1, createdAt: 0 },
+      b3: { id: 'b3', ownerId: 'p2', modality: 'text', content: 'b3', complexity: 1, createdAt: 0 }
+    },
+    edges: {
+      e1: { id: 'e1', from: 'b1', to: 'b3', label: 'analogy', justification: '' },
+      e2: { id: 'e2', from: 'b2', to: 'b3', label: 'analogy', justification: '' },
+      e3: { id: 'e3', from: 'b1', to: 'b2', label: 'analogy', justification: '' }
+    },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0
+  };
+
+  const scroll = judge(state);
+  assert.equal(scroll.winner, 'p1');
+  assert.ok(Math.abs(scroll.scores['p1'].total - 0.6774576540013667) < 1e-9);
+  assert.ok(Math.abs(scroll.scores['p2'].total - 0.6612243230363666) < 1e-9);
+});

--- a/apps/server/test/match.test.ts
+++ b/apps/server/test/match.test.ts
@@ -13,12 +13,12 @@ test('players can join a match and be listed in state', async (t) => {
     env: { ...process.env, PORT: '9998' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  await new Promise(res => setTimeout(res, 500));
+  await new Promise(res => setTimeout(res, 1000));
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://localhost:9998';
+  const base = 'http://127.0.0.1:9998';
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -1,0 +1,141 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function startServer(port: number){
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore','pipe','pipe']
+  });
+  return server;
+}
+
+test('cast rejects when insight and wild exhausted', async (t) => {
+  const port = 9997;
+  const server = startServer(port);
+  await new Promise(r => setTimeout(r, 500));
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('A');
+  await join('B');
+
+  const cast = async () => {
+    const bead = {
+      id: `b_${Math.random().toString(36).slice(2,8)}`,
+      ownerId: p1.id,
+      modality: 'text',
+      content: 'x',
+      complexity: 1,
+      createdAt: Date.now()
+    };
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p1.id,
+      type: 'cast',
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    return fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+  };
+
+  // spend 5 insight and 1 wild
+  for(let i=0;i<6;i++){
+    const res = await cast();
+    assert.equal(res.status, 200);
+  }
+
+  // verify resources exhausted
+  const state = await (await fetch(`${base}/match/${matchId}`)).json();
+  const player = state.players.find((p:any)=>p.id===p1.id);
+  assert.equal(player.resources.insight, 0);
+  assert.equal(player.resources.wildAvailable, false);
+
+  // seventh cast should be rejected
+  const res = await cast();
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Not enough insight');
+});
+
+test('bind uses restraint then wild then rejects', async (t) => {
+  const port = 9996;
+  const server = startServer(port);
+  await new Promise(r => setTimeout(r, 500));
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('A');
+  await join('B');
+
+  // cast two beads to bind
+  const castBead = async (id:string) => {
+    const bead = { id, ownerId: p1.id, modality: 'text', content: 'y', complexity:1, createdAt:Date.now() };
+    const move = { id:`m_${Math.random().toString(36).slice(2,8)}`, playerId:p1.id, type:'cast', payload:{ bead }, timestamp:Date.now(), durationMs:0, valid:true };
+    await fetch(`${base}/match/${matchId}/move`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(move)});
+  };
+  const b1 = `b_${Math.random().toString(36).slice(2,8)}`;
+  const b2 = `b_${Math.random().toString(36).slice(2,8)}`;
+  await castBead(b1); await castBead(b2);
+
+  const bind = async () => {
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p1.id,
+      type: 'bind',
+      payload: { from: b1, to: b2, label: 'analogy', justification: 'First. Second.' },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    return fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+  };
+
+  // spend 2 restraint and 1 wild
+  for(let i=0;i<3;i++){
+    const res = await bind();
+    assert.equal(res.status, 200);
+  }
+
+  // fourth bind should be rejected
+  const res = await bind();
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Not enough restraint');
+});

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('turn switches to next player after move', async (t) => {
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: '9997' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  await new Promise(res => setTimeout(res, 1000));
+  t.after(() => {
+    server.kill();
+  });
+
+  const base = 'http://127.0.0.1:9997';
+
+  const matchRes = await fetch(`${base}/match`, { method: 'POST' });
+  const match = await matchRes.json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+  const p2 = await join('Bob');
+
+  let stateRes = await fetch(`${base}/match/${matchId}`);
+  let state = await stateRes.json();
+  assert.equal(state.currentPlayerId, p1.id);
+
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2, 8)}`,
+    ownerId: p1.id,
+    modality: 'text',
+    title: 'Idea',
+    content: 'simple',
+    complexity: 1,
+    createdAt: Date.now(),
+    seedId: match.seeds[0]?.id
+  };
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2, 8)}`,
+    playerId: p1.id,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 1000,
+    valid: true
+  };
+  await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+
+  stateRes = await fetch(`${base}/match/${matchId}`);
+  state = await stateRes.json();
+  assert.equal(state.currentPlayerId, p2.id);
+});

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,25 @@
+# Web Client
+
+Vite + React front‑end for the Glass Bead Game. It connects to the server's REST
+and WebSocket APIs to let two players create matches, cast beads, bind them and
+request judgments.
+
+The UI uses Tailwind CSS and persists the last used match ID and handle in local
+storage for convenience.
+
+## Development
+
+Run workspace scripts from the repository root:
+
+```bash
+# Start the dev server on http://localhost:5173
+npm --workspace apps/web run dev
+
+# Create a production build
+npm --workspace apps/web run build
+
+# Type‑check the project
+npm --workspace apps/web run typecheck
+```
+
+The built assets will be output to `dist/`.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,8 @@ export default function App() {
   const [scroll, setScroll] = useState<JudgmentScroll | null>(null);
   const [beadText, setBeadText] = useState("");
   const wsRef = useRef<WebSocket | null>(null);
+  const currentPlayer = state?.players.find(p => p.id === state.currentPlayerId);
+  const isMyTurn = currentPlayer?.id === playerId;
 
   useEffect(() => { localStorage.setItem("matchId", matchId); }, [matchId]);
   useEffect(() => { localStorage.setItem("handle", handle); }, [handle]);
@@ -175,6 +177,14 @@ export default function App() {
             <button onClick={joinMatch} className="px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Join</button>
           </div>
         </div>
+        {state && (
+          <div className="pt-4">
+            <h2 className="text-sm uppercase tracking-wide text-[var(--muted)]">Turn</h2>
+            <p className="text-sm mt-1">
+              {currentPlayer?.handle || currentPlayer?.id || ""} {isMyTurn && "(your turn)"}
+            </p>
+          </div>
+        )}
         <div className="pt-4">
           <h2 className="text-sm uppercase tracking-wide text-[var(--muted)]">Seeds</h2>
           <ul className="text-sm mt-2 space-y-1">
@@ -193,13 +203,13 @@ export default function App() {
           />
           <button
             onClick={castBead}
-            disabled={!beadText.trim()}
+            disabled={!beadText.trim() || !isMyTurn}
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cast Bead
           </button>
-          <button onClick={bindFirstTwo} className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500">Bind First Two</button>
-          <button onClick={requestJudgment} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500">Request Judgment</button>
+          <button onClick={bindFirstTwo} disabled={!isMyTurn} className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed">Bind First Two</button>
+          <button onClick={requestJudgment} disabled={!isMyTurn} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed">Request Judgment</button>
           <button onClick={exportLog} className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Export Log</button>
         </div>
         <p className="text-xs text-[var(--muted)] pt-4">MVP: cast text beads, bind, get a stub judgment.</p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation Index
+
+Additional project documentation lives in this directory:
+
+- `VISION.md` – high‑level goals and guiding principles
+- `PRD.md` – product requirements for the MVP
+- `development-plan.md` – planned milestones and tasks
+- `architecture.svg` – overview of the current system architecture
+
+These documents complement the main `README.md` in the repository root.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,29 @@
+# @gbg/types
+
+Shared TypeScript types and helper utilities for the Glass Bead Game.
+
+This package exports the core domain models (`Player`, `Bead`, `Edge`, `Move`,
+`GameState` and more) along with sanitization and validation helpers such as
+`sanitizeMarkdown`, `validateSeed`, `validateMove`, `applyMove` and
+`replayMoves`.
+
+## Development
+
+From the repository root you can run the following scripts against this
+workspace:
+
+```bash
+# Build once
+npm --workspace packages/types run build
+
+# Continuous compilation
+npm --workspace packages/types run dev
+
+# Type‑check without emitting output
+npm --workspace packages/types run typecheck
+
+# Run unit tests
+npm --workspace packages/types test
+```
+
+The compiled artifacts are emitted to `dist/` and are not committed.

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -1,0 +1,83 @@
+import type { Bead, Edge } from "./index.js";
+
+export interface GraphState {
+  beads: Record<string, Bead>;
+  edges: Record<string, Edge>;
+  outbound: Record<string, string[]>; // edge ids keyed by source bead
+  inbound: Record<string, string[]>; // edge ids keyed by target bead
+}
+
+export function addBead(state: GraphState, bead: Bead): void {
+  state.beads[bead.id] = bead;
+  if (!state.outbound[bead.id]) state.outbound[bead.id] = [];
+  if (!state.inbound[bead.id]) state.inbound[bead.id] = [];
+}
+
+export function addEdge(state: GraphState, edge: Edge): void {
+  state.edges[edge.id] = edge;
+  if (!state.outbound[edge.from]) state.outbound[edge.from] = [];
+  state.outbound[edge.from].push(edge.id);
+  if (!state.inbound[edge.to]) state.inbound[edge.to] = [];
+  state.inbound[edge.to].push(edge.id);
+}
+
+export function removeEdge(state: GraphState, edgeId: string): void {
+  const edge = state.edges[edgeId];
+  if (!edge) return;
+  state.outbound[edge.from] = (state.outbound[edge.from] || []).filter((id) => id !== edgeId);
+  state.inbound[edge.to] = (state.inbound[edge.to] || []).filter((id) => id !== edgeId);
+  delete state.edges[edgeId];
+}
+
+export function neighbors(state: GraphState, nodeId: string): string[] {
+  const outs = (state.outbound[nodeId] || []).map((id) => state.edges[id]?.to);
+  const ins = (state.inbound[nodeId] || []).map((id) => state.edges[id]?.from);
+  return Array.from(new Set([...outs, ...ins].filter(Boolean)));
+}
+
+export function longestPathFrom(state: GraphState, start: string): string[] {
+  const visited = new Set<string>();
+
+  function dfs(node: string): string[] {
+    visited.add(node);
+    let best: string[] = [node];
+    for (const edgeId of state.outbound[node] || []) {
+      const edge = state.edges[edgeId];
+      if (!edge || visited.has(edge.to)) continue;
+      const path = dfs(edge.to);
+      if (path.length + 1 > best.length) {
+        best = [node, ...path];
+      }
+    }
+    visited.delete(node);
+    return best;
+  }
+
+  return dfs(start);
+}
+
+export function maxWeightedPathFrom(
+  state: GraphState,
+  start: string,
+  weightFn: (edge: Edge) => number
+): { path: string[]; weight: number } {
+  const visited = new Set<string>();
+
+  function dfs(node: string): { path: string[]; weight: number } {
+    visited.add(node);
+    let best: { path: string[]; weight: number } = { path: [node], weight: 0 };
+    for (const edgeId of state.outbound[node] || []) {
+      const edge = state.edges[edgeId];
+      if (!edge || visited.has(edge.to)) continue;
+      const child = dfs(edge.to);
+      const total = child.weight + weightFn(edge);
+      if (total > best.weight) {
+        best = { path: [node, ...child.path], weight: total };
+      }
+    }
+    visited.delete(node);
+    return best;
+  }
+
+  return dfs(start);
+}

--- a/packages/types/test/graph.test.ts
+++ b/packages/types/test/graph.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GraphState,
+  addBead,
+  addEdge,
+  removeEdge,
+  neighbors,
+  longestPathFrom,
+  maxWeightedPathFrom,
+} from '../src/graph.ts';
+import type { Bead, Edge } from '../src/index.ts';
+
+test('add and remove edges update adjacency lists', () => {
+  const state: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const a: Bead = { id: 'a', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  const b: Bead = { id: 'b', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  const c: Bead = { id: 'c', ownerId: 'p', modality: 'text', content: '', complexity: 1, createdAt: 0 };
+  addBead(state, a);
+  addBead(state, b);
+  addBead(state, c);
+
+  const e1: Edge = { id: 'e1', from: 'a', to: 'b', label: 'analogy', justification: '' };
+  const e2: Edge = { id: 'e2', from: 'b', to: 'c', label: 'analogy', justification: '' };
+  const e3: Edge = { id: 'e3', from: 'a', to: 'c', label: 'analogy', justification: '' };
+  addEdge(state, e1);
+  addEdge(state, e2);
+  addEdge(state, e3);
+
+  assert.deepEqual(new Set(neighbors(state, 'a')), new Set(['b', 'c']));
+  removeEdge(state, 'e3');
+  assert.deepEqual(new Set(neighbors(state, 'a')), new Set(['b']));
+  assert.ok(!state.edges['e3']);
+});
+
+test('longest and weighted path search', () => {
+  const state: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const beads: Bead[] = ['a', 'b', 'c'].map((id) => ({
+    id,
+    ownerId: 'p',
+    modality: 'text',
+    content: '',
+    complexity: 1,
+    createdAt: 0,
+  }));
+  beads.forEach((b) => addBead(state, b));
+
+  const edges: Edge[] = [
+    { id: 'e1', from: 'a', to: 'b', label: 'analogy', justification: '' },
+    { id: 'e2', from: 'b', to: 'c', label: 'analogy', justification: '' },
+    { id: 'e3', from: 'a', to: 'c', label: 'analogy', justification: '' },
+  ];
+  edges.forEach((e) => addEdge(state, e));
+
+  const longest = longestPathFrom(state, 'a');
+  assert.deepEqual(longest, ['a', 'b', 'c']);
+
+  const weightFn = (edge: Edge) => ({ e1: 2, e2: 5, e3: 1 }[edge.id] ?? 0);
+  const weighted = maxWeightedPathFrom(state, 'a', weightFn);
+  assert.deepEqual(weighted.path, ['a', 'b', 'c']);
+  assert.equal(weighted.weight, 7);
+});

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -33,6 +33,6 @@ echo ""
 # Step 4: Start development server
 echo "🎮 Starting development server..."
 echo "   - Web app will be available at http://localhost:5173"
-echo "   - Server will be available at http://localhost:3000"
+echo "   - Server will be available at http://localhost:8787"
 echo ""
 npm run dev


### PR DESCRIPTION
## Summary
- integrate perturbation-based resilience evaluation into judge pipeline
- remove judging stub from server and expose weak spot edge IDs
- update deterministic judge test expectations

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test --import tsx apps/server/test/resilience.test.ts`
- `node --test --import tsx apps/server/test/*.test.ts` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5599af84832c9099b528a19566c9