### PR TITLE
fix: retain edge ids for bind moves

### DIFF
--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -45,6 +45,13 @@ export default function registerMoveRoute(
             move.payload.justification
           );
         }
+        if (
+          move.payload &&
+          move.payload.edgeId === undefined &&
+          move.payload.id !== undefined
+        ) {
+          move.payload.edgeId = move.payload.id;
+        }
       }
       const validation = validateMove(move, state);
       if (!validation.ok) {


### PR DESCRIPTION
## Summary
- ensure bind moves map `payload.id` to `payload.edgeId`

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test --import tsx apps/server/test/cast.test.ts`
- `node --test --import tsx apps/server/test/match.test.ts`
- `node --test --import tsx apps/server/test/metrics.test.ts`
- `node --test --import tsx apps/server/test/judge.test.ts`
- `node --test --import tsx apps/server/test/moves.test.ts`
- `node --test --import tsx apps/server/test/turn.test.ts`
- `node --test --import tsx packages/types/test/graph.test.ts`
- `node --test --import tsx packages/types/test/resonance.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf61e9e268832ca4598fe8ddcf9863