### PR TITLE
feat: add optional LLM judge using ollama

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,7 +13,8 @@
     "uuid": "^9.0.1",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "@gbg/types": "file:../../packages/types"
+    "@gbg/types": "file:../../packages/types",
+    "ollama": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.1",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@gbg/types";
 import registerMoveRoute from "./routes/move.js";
 import judge from "./judge/index.js";
+import judgeWithLLM from "./judge/llm.js";
 
 const fastify = Fastify({ logger: false });
 await fastify.register(cors, { origin: true });
@@ -119,7 +120,8 @@ fastify.post<{ Params: { id: string } }>("/match/:id/judge", async (req, reply) 
   const id = req.params.id;
   const state = matches.get(id);
   if(!state) return reply.code(404).send({ error: "No such match" });
-  const scroll = judge(state);
+  const useLlm = !!process.env.LLM_MODEL;
+  const scroll = useLlm ? await judgeWithLLM(state) : judge(state);
   broadcast(id, "end:judgment", scroll);
   return reply.send(scroll);
 });

--- a/apps/server/src/judge/llm.ts
+++ b/apps/server/src/judge/llm.ts
@@ -1,0 +1,44 @@
+import { GameState, JudgmentScroll } from '@gbg/types';
+import { Ollama } from 'ollama';
+import judge from './index.js';
+
+/**
+ * Use a local Ollama model to select the winning player.
+ * Falls back to the deterministic judge if the model fails.
+ */
+export async function judgeWithLLM(state: GameState): Promise<JudgmentScroll> {
+  const baseline = judge(state);
+  const model = process.env.LLM_MODEL || 'qwen7b:latest';
+  const client = new Ollama();
+
+  try {
+    const summary = state.players.map(p => {
+      const beads = Object.values(state.beads).filter(b => b.ownerId === p.id).length;
+      const edges = Object.values(state.edges).filter(e => {
+        const owns = state.beads[e.from]?.ownerId === p.id || state.beads[e.to]?.ownerId === p.id;
+        return owns;
+      }).length;
+      return `${p.id}: beads=${beads} edges=${edges}`;
+    }).join('\n');
+
+    const prompt = `You are the Magister Ludi judging a Glass Bead Game.\n` +
+      `Decide which player is winning based on their contributions.\n` +
+      `${summary}\n` +
+      `Respond ONLY with JSON {"winner":"<playerId>"}`;
+
+    let output = '';
+    for await (const part of client.generate(model, prompt)) {
+      output += part;
+    }
+    const parsed = JSON.parse(output);
+    if (typeof parsed.winner === 'string' && baseline.scores[parsed.winner]) {
+      baseline.winner = parsed.winner.trim();
+    }
+  } catch (err) {
+    console.warn('LLM judge failed', err);
+  }
+
+  return baseline;
+}
+
+export default judgeWithLLM;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@fastify/cors": "^8.5.0",
         "@gbg/types": "file:../../packages/types",
         "fastify": "^4.28.1",
+        "ollama": "^0.1.0",
         "uuid": "^9.0.1",
         "ws": "^8.18.0",
         "zod": "^3.23.8"
@@ -2633,6 +2634,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -3325,6 +3335,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3447,6 +3480,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -4618,6 +4663,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
@@ -4753,6 +4836,15 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
       "license": "MIT"
+    },
+    "node_modules/ollama": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.1.1.tgz",
+      "integrity": "sha512-xZo0thyVuAg4b/m79/GjLlDwNpJ/d3yOJDQf/XI7j5UO0+CRbRDwF6PN3x3u5gFV4/W0ius6nvdcKsVp0fsWhA==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -7074,6 +7166,15 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {


### PR DESCRIPTION
## Summary
- add Ollama-backed judge that asks a local model to pick the winner
- allow server to switch to the LLM judge when `LLM_MODEL` is set
- include `ollama` dependency for server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf70d0cbf8832cb124b96eef2ecccc