### PR TITLE
feat: add AI suggestion button

### DIFF
--- a/apps/server/src/ollama.d.ts
+++ b/apps/server/src/ollama.d.ts
@@ -1,0 +1,1 @@
+declare module "ollama";

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -136,6 +136,20 @@ export default function App() {
     }
   };
 
+  const suggestBead = async () => {
+    if (!state || !playerId) return;
+    try {
+      const res = await api(`/match/${state.id}/ai`, {
+        method: "POST",
+        body: JSON.stringify({ playerId }),
+      });
+      const data = await res.json();
+      if (data?.suggestion) setBeadText(data.suggestion);
+    } catch (err) {
+      console.error("Failed to get suggestion", err);
+    }
+  };
+
   const requestJudgment = async () => {
     if (!state) return;
     try {
@@ -201,6 +215,13 @@ export default function App() {
             className="w-full bg-zinc-900 rounded px-3 py-2 h-24"
             placeholder="Share an idea..."
           />
+          <button
+            onClick={suggestBead}
+            disabled={!isMyTurn}
+            className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Suggest with AI
+          </button>
           <button
             onClick={castBead}
             disabled={!beadText.trim() || !isMyTurn}


### PR DESCRIPTION
## Summary
- add `/match/:id/ai` endpoint that uses Ollama to suggest bead ideas from seed and opponent move
- surface Suggest with AI button in web client to prefill bead text

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test test/*.test.ts` *(fails: Unknown file extension ".ts" for server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7261a0f8832c80cdf288ac3796ab