### PR TITLE
fix: correct Ollama generate usage in LLM judge

### DIFF
--- a/apps/server/src/judge/llm.ts
+++ b/apps/server/src/judge/llm.ts
@@ -27,8 +27,9 @@ export async function judgeWithLLM(state: GameState): Promise<JudgmentScroll> {
       `Respond ONLY with JSON {"winner":"<playerId>"}`;
 
     let output = '';
-    for await (const part of client.generate(model, prompt)) {
-      output += part;
+    const stream = await client.generate({ model, prompt, stream: true });
+    for await (const part of stream) {
+      output += part.response;
     }
     const parsed = JSON.parse(output);
     if (typeof parsed.winner === 'string' && baseline.scores[parsed.winner]) {

--- a/apps/server/src/ollama.d.ts
+++ b/apps/server/src/ollama.d.ts
@@ -1,0 +1,1 @@
+declare module 'ollama';


### PR DESCRIPTION
## Summary
- stream from Ollama using options object and collect response tokens
- add ambient module declaration for ollama

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf7487fde8832ca9940f16d6a5eb80