### PR TITLE
feat: add LLM judge tests with DI

### DIFF
--- a/apps/server/src/judge/llm.ts
+++ b/apps/server/src/judge/llm.ts
@@ -2,14 +2,20 @@ import { GameState, JudgmentScroll } from '@gbg/types';
 import { Ollama } from 'ollama';
 import judge from './index.js';
 
+interface LLMClient {
+  generate(model: string, prompt: string): AsyncIterable<string>;
+}
+
 /**
  * Use a local Ollama model to select the winning player.
  * Falls back to the deterministic judge if the model fails.
  */
-export async function judgeWithLLM(state: GameState): Promise<JudgmentScroll> {
+export async function judgeWithLLM(
+  state: GameState,
+  client: LLMClient = new Ollama(),
+): Promise<JudgmentScroll> {
   const baseline = judge(state);
   const model = process.env.LLM_MODEL || 'qwen7b:latest';
-  const client = new Ollama();
 
   try {
     const summary = state.players.map(p => {

--- a/apps/server/test/llm.test.ts
+++ b/apps/server/test/llm.test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import judgeWithLLM from '../src/judge/llm.ts';
+import { GameState } from '@gbg/types';
+
+const state: GameState = {
+  id: 'm1',
+  round: 1,
+  phase: 'play',
+  players: [
+    { id: 'p1', handle: 'A', resources: { insight: 0, restraint: 0, wildAvailable: false } },
+    { id: 'p2', handle: 'B', resources: { insight: 0, restraint: 0, wildAvailable: false } }
+  ],
+  seeds: [],
+  beads: {
+    b1: { id: 'b1', ownerId: 'p1', modality: 'text', content: 'b1', complexity: 1, createdAt: 0 },
+    b2: { id: 'b2', ownerId: 'p1', modality: 'text', content: 'b2', complexity: 1, createdAt: 0 },
+    b3: { id: 'b3', ownerId: 'p2', modality: 'text', content: 'b3', complexity: 1, createdAt: 0 }
+  },
+  edges: {
+    e1: { id: 'e1', from: 'b1', to: 'b3', label: 'analogy', justification: '' },
+    e2: { id: 'e2', from: 'b2', to: 'b3', label: 'analogy', justification: '' },
+    e3: { id: 'e3', from: 'b1', to: 'b2', label: 'analogy', justification: '' }
+  },
+  moves: [],
+  createdAt: 0,
+  updatedAt: 0
+};
+
+test('LLM judge overrides baseline winner with model output', async () => {
+  const client = {
+    generate(_model: string, _prompt: string) {
+      return (async function* () {
+        yield '{"winner":"p2"}';
+      })();
+    }
+  };
+
+  const scroll = await judgeWithLLM(state, client);
+  assert.equal(scroll.winner, 'p2');
+});
+
+test('LLM judge falls back to baseline winner on error', async () => {
+  const client = {
+    generate() {
+      return (async function* () {
+        throw new Error('fail');
+      })();
+    }
+  };
+
+  const scroll = await judgeWithLLM(state, client);
+  assert.equal(scroll.winner, 'p1');
+});


### PR DESCRIPTION
## Summary
- allow dependency injection for LLM judge
- add tests for LLM judge success and error paths

## Testing
- `node --test --import tsx apps/server/test/judge.test.ts apps/server/test/llm.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf74fb6200832c8afe923b3f31178d