### PR TITLE
test: add match log endpoint coverage

### DIFF
--- a/apps/server/test/log.test.ts
+++ b/apps/server/test/log.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { startServer, createMatchWithMoves } from './server.helper.js';
+
+// Ensure we can download match log with moves and beads
+
+test('match log download contains moves and beads', async (t) => {
+  const port = 9995;
+  const server = await startServer(port);
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const { matchId, bead } = await createMatchWithMoves(base);
+
+  const res = await fetch(`${base}/match/${matchId}/log`);
+  assert.equal(res.headers.get('content-disposition'), `attachment; filename=match-${matchId}.json`);
+  const body = await res.json();
+  assert.ok(Array.isArray(body.moves) && body.moves.length > 0);
+  assert.ok(body.beads[bead.id]);
+});

--- a/apps/server/test/server.helper.ts
+++ b/apps/server/test/server.helper.ts
@@ -1,0 +1,56 @@
+import { spawn, ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export async function startServer(port: number): Promise<ChildProcess>{
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore','pipe','pipe']
+  });
+  await new Promise(res => setTimeout(res, 1000));
+  return server;
+}
+
+export async function createMatchWithMoves(base: string){
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+  await join('Bob');
+
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2,8)}`,
+    ownerId: p1.id,
+    modality: 'text',
+    content: 'example',
+    complexity: 1,
+    createdAt: Date.now()
+  };
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2,8)}`,
+    playerId: p1.id,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+  await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+  return { matchId, bead, move };
+}
+


### PR DESCRIPTION
## Summary
- add server test helper for spawning server and seeding match
- test `/match/{id}/log` returns downloadable JSON with moves and beads

## Testing
- `npm run build:types`
- `npm run build:server`
- `npx tsx --test apps/server/test/log.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf74fcd918832c953374676fb21a70