### PR TITLE
feat(web): centralize websocket state with useMatchState hook

### DIFF
--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import * as d3 from "d3";
 import type { GameState } from "@gbg/types";
+import useMatchState from "./hooks/useMatchState";
 
 interface Node extends d3.SimulationNodeDatum {
   id: string;
@@ -31,23 +32,8 @@ export default function GraphView({
   width = 800,
   height = 600,
 }: GraphViewProps) {
-  const [state, setState] = useState<GameState | null>(initialState ?? null);
+  const { state } = useMatchState(matchId, { initialState });
   const svgRef = useRef<SVGSVGElement | null>(null);
-
-  // Subscribe to websocket for live updates
-  useEffect(() => {
-    if (!matchId) return;
-    const ws = new WebSocket(`ws://localhost:8787/?matchId=${matchId}`);
-    ws.onmessage = (e) => {
-      try {
-        const msg = JSON.parse(e.data);
-        if (msg.type === "state:update") setState(msg.payload as GameState);
-      } catch {
-        // ignore malformed
-      }
-    };
-    return () => ws.close();
-  }, [matchId]);
 
   // Render graph using d3 whenever state or selection changes
   useEffect(() => {

--- a/apps/web/src/hooks/useMatchState.ts
+++ b/apps/web/src/hooks/useMatchState.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GameState } from "@gbg/types";
+
+interface WsMsg {
+  type: string;
+  payload: any;
+}
+
+/**
+ * React hook managing websocket connection and game state updates for a match.
+ *
+ * @param matchId - id of the match to connect to
+ * @param opts.autoConnect - whether to automatically connect when matchId changes
+ * @param opts.initialState - optional initial state before websocket messages arrive
+ */
+export default function useMatchState(
+  matchId?: string,
+  opts: { autoConnect?: boolean; initialState?: GameState | null } = {}
+) {
+  const { autoConnect = true, initialState = null } = opts;
+  const [state, setState] = useState<GameState | null>(initialState);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const disconnect = useCallback(() => {
+    wsRef.current?.close();
+    wsRef.current = null;
+  }, []);
+
+  const connect = useCallback(
+    (id?: string) => {
+      const targetId = id ?? matchId;
+      if (!targetId) return;
+      // Close any existing connection
+      wsRef.current?.close();
+      const ws = new WebSocket(`ws://localhost:8787/?matchId=${targetId}`);
+      ws.onmessage = (e) => {
+        try {
+          const msg: WsMsg = JSON.parse(e.data);
+          if (msg.type === "state:update") {
+            setState(msg.payload as GameState);
+          }
+        } catch {
+          // ignore malformed messages
+        }
+      };
+      wsRef.current = ws;
+    },
+    [matchId]
+  );
+
+  // Automatically connect/disconnect when matchId changes
+  useEffect(() => {
+    if (autoConnect) {
+      connect(matchId);
+    }
+    return () => {
+      disconnect();
+    };
+  }, [matchId, autoConnect, connect, disconnect]);
+
+  return { state, setState, connect, disconnect };
+}
+


### PR DESCRIPTION
## Summary
- add reusable `useMatchState` hook to manage websocket state updates
- wire App and GraphView components to hook and remove inline websocket logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf74fe49dc832c9c5c3b66595dfb49