### PR TITLE
fix: enable streaming generate call

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -130,8 +130,9 @@ fastify.post<{ Params: { id: string } }>("/match/:id/ai", async (req, reply) => 
     const model = process.env.LLM_MODEL || "qwen7b:latest";
     const client = new Ollama();
     const prompt = `Seed: ${seed}\nOpponent: ${opponent}\nRespond with a short bead idea:`;
-    for await (const part of client.generate(model, prompt)) {
-      suggestion += part;
+    const stream = await client.generate({ model, prompt, stream: true });
+    for await (const part of stream) {
+      suggestion += part.response ?? "";
     }
   } catch (err) {
     console.warn("LLM suggest failed", err);


### PR DESCRIPTION
## Summary
- request streaming from `Ollama.generate` and read token responses for AI suggestions

## Testing
- `npm --workspace packages/types test`
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `node --test apps/server/test/*.test.ts` *(fails: Unknown file extension ".ts")*

------
https://chatgpt.com/codex/tasks/task_e_68bf75a57bbc832c955b20c5cec0c01e