### PR TITLE
fix: ignore web tests in production build

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -8,5 +8,6 @@
     "jsx": "react-jsx",
     "moduleResolution": "bundler"
   },
-  "include": ["src", "vite-env.d.ts"]
+  "include": ["src", "vite-env.d.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "types": ["jest", "node", "@testing-library/jest-dom"]
-  }
+  },
+  "exclude": []
 }


### PR DESCRIPTION
## Summary
- avoid compiling test files during web build
- allow tests to include jest-dom matchers

## Testing
- `npm --workspace apps/web test`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68bf82fd2a50832cb1479160f272f35a