### PR TITLE
docs: add architecture notes to index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Additional project documentation lives in this directory:
 - `VISION.md` – high‑level goals and guiding principles
 - `PRD.md` – product requirements for the MVP
 - `development-plan.md` – planned milestones and tasks
+- `architecture.md` – architecture notes and resonance path analysis
 - `architecture.svg` – overview of the current system architecture
 - `daily-overview-2025-09-08.md` – comprehensive development history through September 8, 2025
 


### PR DESCRIPTION
## Summary
- include architecture notes and resonance path analysis in docs index

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf83e452ec832ca2619915f873d07e