### PR TITLE
docs: fix PRD link path

### DIFF
--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -1,6 +1,6 @@
 # Development Plan
 
-This plan derives from the MVP and Beta requirements in [`prd.md`](../prd.md). It organizes work into modular deliverables across the repo's packages.
+This plan derives from the MVP and Beta requirements in [`PRD.md`](PRD.md). It organizes work into modular deliverables across the repo's packages.
 
 ## Phase 1 – MVP Core
 


### PR DESCRIPTION
## Summary
- fix relative path to PRD.md in development plan so link resolves in docs directory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find module '@testing-library/react' and other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83df8cac832cbc39bc0bc2dbbf83