### PR TITLE
Add workspace test scripts

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,14 @@
     "build:web": "npm --workspace apps/web run build",
     "build:server": "npm --workspace apps/server run build",
     "build:types": "npm --workspace packages/types run build",
+    "test": "npm-run-all test:*",
+    "test:web": "npm --workspace apps/web run test",
+    "test:server": "npm --workspace apps/server run test",
+    "test:types": "npm --workspace packages/types run test",
     "typecheck": "npm-run-all typecheck:types typecheck:web typecheck:server",
     "typecheck:web": "npm --workspace apps/web run typecheck",
     "typecheck:server": "npm --workspace apps/server run typecheck",
-    "typecheck:types": "npm --workspace packages/types run build"
+    "typecheck:types": "npm --workspace packages/types run typecheck"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"


### PR DESCRIPTION
## Summary
- add root test script to run workspace tests
- expose test scripts for web, server, and types workspaces
- run typecheck in types package and add server test command

## Testing
- `npm test` *(fails: fetch failed in server tests)*
- `npm --workspace packages/types run test`


------
https://chatgpt.com/codex/tasks/task_e_68bf83e0897c832ca72a9fe79a90f218