### PR TITLE
docs(web): document tests and state

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -5,7 +5,9 @@ and WebSocket APIs to let two players create matches, cast beads, bind them and
 request judgments.
 
 The UI uses Tailwind CSS and persists the last used match ID and handle in local
-storage for convenience.
+storage for convenience. An AI suggestion button can propose bead ideas, and
+match state is managed by the `useMatchState` hook to keep the UI in sync via
+WebSockets.
 
 ## Development
 
@@ -20,6 +22,9 @@ npm --workspace apps/web run build
 
 # Type‑check the project
 npm --workspace apps/web run typecheck
+
+# Run tests
+npm --workspace apps/web run test
 ```
 
 The built assets will be output to `dist/`.


### PR DESCRIPTION
## Summary
- describe AI suggestion button and match state hook
- note how to run tests in web workspace

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config apps/web/jest.config.cjs --runInBand --watchAll=false` *(fails: ReferenceError: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83e29e18832ca2412b9071ed1614