### PR TITLE
fix ollama generate usage in suggestion route

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -130,9 +130,8 @@ fastify.post<{ Params: { id: string } }>("/match/:id/ai", async (req, reply) => 
     const model = process.env.LLM_MODEL || "qwen7b:latest";
     const client = new Ollama();
     const prompt = `Seed: ${seed}\nOpponent: ${opponent}\nRespond with a short bead idea:`;
-    const stream = await client.generate({ model, prompt, stream: true });
-    for await (const part of stream) {
-      suggestion += part.response ?? "";
+    for await (const part of client.generate(model, prompt)) {
+      suggestion += part;
     }
   } catch (err) {
     console.warn("LLM suggest failed", err);


### PR DESCRIPTION
## Summary
- use Ollama's generate(model, prompt) signature for bead suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:types`
- `npm run typecheck:server`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68bf879c0698832c87a2ea7ca4ec95ee