### PR TITLE
chore(web): configure dist output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 /dist/
 packages/*/dist/
 apps/*/dist/
+apps/web/dist/
 
 # Logs
 npm-debug.log*

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.json && vite build",
+    "build": "rm -rf dist && tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "jest"

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,9 @@
       "@gbg/types": ["../../packages/types/src"]
     },
     "jsx": "react-jsx",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "noEmit": false
   },
   "include": ["src", "vite-env.d.ts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]


### PR DESCRIPTION
## Summary
- configure web tsconfig to emit JavaScript to `dist`
- clean `apps/web/dist` before building
- ignore web build artifacts

## Testing
- `npm test` *(fails: Lifecycle script `test` failed with error: npm error command sh -c node --test --import tsx test/*.test.ts)*
- `npm --workspace apps/web run test`
- `npm --workspace apps/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8dd0f938832c8203b4660a9ce6cc