### PR TITLE
test(web): drop JS transforms from Jest config

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -1,12 +1,13 @@
 module.exports = {
   rootDir: __dirname,
-  preset: 'ts-jest/presets/js-with-ts-esm',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@gbg/types$': '<rootDir>/../../packages/types/src',
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^d3$': '<rootDir>/../../node_modules/d3/dist/d3.js',
   },
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', { useESM: true, tsconfig: '<rootDir>/tsconfig.test.json' }],


### PR DESCRIPTION
## Summary
- switch web Jest preset to `ts-jest/presets/default-esm` and avoid transforming `.js`
- map `d3` to its bundled UMD build so tests don't require JS transforms

## Testing
- `npm --workspace apps/web test`
- `npm --workspace apps/web run typecheck`
- `npm test` *(fails: node --test --import tsx test/*.test.ts in apps/server)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8dd8c794832c93dd3ad1280a9519