### PR TITLE
Use CommonJS for web tests

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -1,15 +1,14 @@
 module.exports = {
   rootDir: __dirname,
-  preset: 'ts-jest/presets/js-with-ts-esm',
+  preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@gbg/types$': '<rootDir>/../../packages/types/src',
-    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^d3$': '<rootDir>/../../node_modules/d3/dist/d3.js',
   },
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { useESM: true, tsconfig: '<rootDir>/tsconfig.test.json' }],
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
   },
   transformIgnorePatterns: [
     'node_modules/(?!(d3|d3-[^/]+|internmap|delaunator|robust-predicates)/)',

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "CommonJS",
     "moduleResolution": "node",
     "types": ["jest", "node", "@testing-library/jest-dom"]
   },


### PR DESCRIPTION
## Summary
- configure web test tsconfig to emit CommonJS modules
- run Jest in CommonJS mode with ts-jest preset and map d3 to its UMD build

## Testing
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bf8dd5c27c832c9757f2b69c17a64c