### PR TITLE
test: use unique ports in server tests

### DIFF
--- a/apps/server/test/metrics.test.ts
+++ b/apps/server/test/metrics.test.ts
@@ -10,7 +10,7 @@ test('metrics endpoint reports move counts and latency', async (t) => {
   const cwd = path.join(__dirname, '..');
   const server = spawn('node', ['dist/index.js'], {
     cwd,
-    env: { ...process.env, PORT: '9997' },
+    env: { ...process.env, PORT: '9994' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
   await new Promise(res => setTimeout(res, 1000));
@@ -18,7 +18,7 @@ test('metrics endpoint reports move counts and latency', async (t) => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9997';
+  const base = 'http://127.0.0.1:9994';
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -17,7 +17,7 @@ function startServer(port: number){
 }
 
 test('cast rejects when insight and wild exhausted', async (t) => {
-  const port = 9997;
+  const port = 9993;
   const server = startServer(port);
   await new Promise(r => setTimeout(r, 1000));
   t.after(() => server.kill());

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -10,7 +10,7 @@ test('turn switches to next player after move', async (t) => {
   const cwd = path.join(__dirname, '..');
   const server = spawn('node', ['dist/index.js'], {
     cwd,
-    env: { ...process.env, PORT: '9997' },
+    env: { ...process.env, PORT: '9992' },
     stdio: ['ignore', 'pipe', 'pipe']
   });
   await new Promise(res => setTimeout(res, 1000));
@@ -18,7 +18,7 @@ test('turn switches to next player after move', async (t) => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9997';
+  const base = 'http://127.0.0.1:9992';
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();


### PR DESCRIPTION
## Summary
- allocate separate ports for server integration tests to prevent conflicts
- update metrics, moves, and turn tests to use ports 9994, 9993, and 9992 respectively

## Testing
- `npm run test:server`

------
https://chatgpt.com/codex/tasks/task_e_68bf96c087e0832cb26d1a9aabe325ac