### PR TITLE
test: await bead render

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -103,7 +103,7 @@ describe('App', () => {
     });
 
     const bead1 = await screen.findByTestId('bead-b1');
-    const bead2 = screen.getByTestId('bead-b2');
+    const bead2 = await screen.findByTestId('bead-b2');
 
     fireEvent.click(bead1);
     fireEvent.click(bead2);


### PR DESCRIPTION
## Summary
- stabilize bead binding test by waiting for both beads to render before interaction

## Testing
- `npm --workspace apps/web test`
- `npm test` *(fails: fetch failed in @gbg/server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa0aa2f74832cb4d68194200a0622