### PR TITLE
Fix failing App test by ensuring Jest uses TypeScript source files

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
   moduleNameMapper: {
     '^@gbg/types$': '<rootDir>/../../packages/types/src',
     '^d3$': '<rootDir>/../../node_modules/d3/dist/d3.js',
+    '^./App$': '<rootDir>/src/App.tsx',
   },
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', { 

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -102,6 +102,12 @@ describe('App', () => {
       );
     });
 
+    // Wait for beads to be rendered
+    await waitFor(() => {
+      expect(screen.getByText('Idea 1')).toBeInTheDocument();
+      expect(screen.getByText('Idea 2')).toBeInTheDocument();
+    });
+
     const bead1 = await screen.findByTestId('bead-b1');
     const bead2 = await screen.findByTestId('bead-b2');
 


### PR DESCRIPTION
- Add moduleNameMapper to jest.config.cjs to force Jest to use App.tsx instead of App.js
- Add waitFor in App.test.tsx to ensure beads are rendered before testing interactions
- Fixes test that was failing due to missing data-testid attributes and wrong button text