### PR TITLE
fix server build for tests

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm --workspace @gbg/types run build && npm run build",
     "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure server and types packages build before running tests so cast bead functionality works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa99b68c4832caa31b8f7281efbcf