### PR TITLE
feat: add twist deck and counterpoint move

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import {
   Player,
   Move,
   sanitizeMarkdown,
+  ConstraintCard,
 } from "@gbg/types";
 import registerMoveRoute from "./routes/move.js";
 import judge from "./judge/index.js";
@@ -32,6 +33,29 @@ function sampleSeeds(): GameState["seeds"]{
     {id:"s3", text:"Amnesty", domain:"civics"}
   ];
   return seeds;
+}
+
+function sampleTwists(): ConstraintCard[]{
+  return [
+    {
+      id: 't1',
+      name: 'Text Only',
+      description: 'Only text beads allowed',
+      effect: { modalityLock: ['text'] }
+    },
+    {
+      id: 't2',
+      name: 'Motif Echo',
+      description: 'Relations must be motif-echo',
+      effect: { requiredRelation: 'motif-echo' }
+    },
+    {
+      id: 't3',
+      name: 'Short Justification',
+      description: 'Justifications capped at 40 chars',
+      effect: { justificationLimit: 40 }
+    }
+  ];
 }
 function broadcast(matchId: string, type: string, payload: any){
   const set = sockets.get(matchId); if(!set) return;
@@ -74,7 +98,7 @@ fastify.post("/match", async (req, reply) => {
   const id = randomUUID().slice(0,8);
   const state: GameState = {
     id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds: sampleSeeds(),
-    beads: {}, edges: {}, moves: [], createdAt: now(), updatedAt: now()
+    beads: {}, edges: {}, moves: [], twistDeck: sampleTwists(), createdAt: now(), updatedAt: now()
   };
   matches.set(id, state);
   return reply.send(state);
@@ -113,6 +137,18 @@ fastify.get<{ Params: { id: string } }>("/match/:id/log", async (req, reply) => 
     .header("Content-Type", "application/json")
     .header("Content-Disposition", `attachment; filename=match-${state.id}.json`);
   return reply.send(state);
+});
+
+fastify.post<{ Params: { id: string } }>("/match/:id/twist", async (req, reply) => {
+  const id = req.params.id;
+  const state = matches.get(id);
+  if(!state) return reply.code(404).send({ error: "No such match" });
+  const next = state.twistDeck?.shift();
+  if(!next) return reply.code(400).send({ error: "No twists remaining" });
+  state.twist = next;
+  state.updatedAt = now();
+  broadcast(id, "state:update", state);
+  return reply.send(next);
 });
 
 registerMoveRoute(fastify, { matches, broadcast, now, logMetrics });

--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -31,7 +31,7 @@ export default function registerMoveRoute(
 
       const move = (req.body as any) as Move;
       // sanitize text fields
-      if (move.type === "cast") {
+      if (move.type === "cast" || move.type === "mirror") {
         const bead = move.payload?.bead as Bead;
         if (bead) {
           bead.content = sanitizeMarkdown(bead.content);
@@ -39,7 +39,7 @@ export default function registerMoveRoute(
             bead.title = sanitizeMarkdown(bead.title);
           }
         }
-      } else if (move.type === "bind") {
+      } else if (move.type === "bind" || move.type === "counterpoint") {
         if (typeof move.payload?.justification === "string") {
           move.payload.justification = sanitizeMarkdown(
             move.payload.justification


### PR DESCRIPTION
## Summary
- add counterpoint move type and twist deck state with validation for mirror/counterpoint
- manage twist cards on the server with draw endpoint and move sanitization
- show current twist in UI, gate illegal moves, and enable counterpoint actions

## Testing
- `npm --workspace packages/types test`
- `npm --workspace apps/server test`
- `npm --workspace apps/web test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa64da68832ca7d0a05bc8cd4add