### PR TITLE
feat: add cathedral canonization

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -74,7 +74,7 @@ fastify.post("/match", async (req, reply) => {
   const id = randomUUID().slice(0,8);
   const state: GameState = {
     id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds: sampleSeeds(),
-    beads: {}, edges: {}, moves: [], createdAt: now(), updatedAt: now()
+    beads: {}, edges: {}, moves: [], cathedral: undefined, createdAt: now(), updatedAt: now()
   };
   matches.set(id, state);
   return reply.send(state);

--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -45,6 +45,10 @@ export default function registerMoveRoute(
             move.payload.justification
           );
         }
+      } else if (move.type === "canonize") {
+        if (typeof move.payload?.content === "string") {
+          move.payload.content = sanitizeMarkdown(move.payload.content);
+        }
       }
       const validation = validateMove(move, state);
       if (!validation.ok) {

--- a/packages/types/test/graph-formation.test.ts
+++ b/packages/types/test/graph-formation.test.ts
@@ -3,15 +3,12 @@ import assert from 'node:assert/strict';
 import {
   validateMove,
   applyMove,
-  addBead,
-  addEdge,
-  neighbors,
   type GameState,
   type Move,
   type Bead,
   type Edge,
-  GraphState,
 } from '../src/index.ts';
+import { addBead, addEdge, neighbors, GraphState } from '../src/graph.ts';
 
 function baseState(): GameState {
   return {

--- a/packages/types/test/resonance.test.ts
+++ b/packages/types/test/resonance.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { GraphState, addBead, addEdge, findStrongestPaths } from "../src/index.ts";
+import { GraphState, addBead, addEdge, findStrongestPaths } from "../src/graph.ts";
 import { score as resonanceScore } from "../../../apps/server/src/judge/resonance.ts";
 
 test("findStrongestPaths returns heaviest paths", () => {


### PR DESCRIPTION
## Summary
- define Cathedral references and helper utilities in shared types
- allow canonize move to persist a Cathedral node and references
- expose cathedral composer UI and render node in graph

## Testing
- `npm --workspace apps/web run test`
- `npm --workspace apps/server run test`
- `npm --workspace packages/types run test`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa68382c832cb93ca392ff7b6854