### PR TITLE
feat: add semantic judge metrics and path visualization

### DIFF
--- a/apps/server/src/judge/integrity.ts
+++ b/apps/server/src/judge/integrity.ts
@@ -1,3 +1,19 @@
-export function score({ edgeCount }: { edgeCount: number }): number {
-  return 0.5 + 0.1 * Math.tanh(edgeCount / 5);
+import type { GameState } from '@gbg/types';
+
+const CONTRADICTION_RE = /\b(?:not|no|never|n't)\b/i;
+
+/**
+ * Integrity penalizes edges whose justifications contain explicit
+ * contradictions or negations, approximating an NLI check.
+ */
+export function score(state: GameState, playerId: string): number {
+  const edges = Object.values(state.edges).filter(
+    (e) => state.beads[e.from]?.ownerId === playerId || state.beads[e.to]?.ownerId === playerId
+  );
+  if (edges.length === 0) return 1;
+  let contradictions = 0;
+  for (const e of edges) {
+    if (CONTRADICTION_RE.test(e.justification)) contradictions++;
+  }
+  return 1 - contradictions / edges.length;
 }

--- a/apps/server/src/judge/novelty.ts
+++ b/apps/server/src/judge/novelty.ts
@@ -1,3 +1,34 @@
-export function score({ beadCount }: { beadCount: number }): number {
-  return 0.4 + 0.1 * Math.tanh(beadCount / 4);
+import type { GameState } from '@gbg/types';
+
+function shingles(text: string, size = 3): string[] {
+  const tokens = text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  const result: string[] = [];
+  for (let i = 0; i <= tokens.length - size; i++) {
+    result.push(tokens.slice(i, i + size).join(' '));
+  }
+  return result;
+}
+
+/**
+ * Novelty rewards beads whose shingles (n-grams) are rare across the board.
+ */
+export function score(state: GameState, playerId: string): number {
+  const counts = new Map<string, number>();
+  for (const bead of Object.values(state.beads)) {
+    for (const s of shingles(bead.content)) {
+      counts.set(s, (counts.get(s) || 0) + 1);
+    }
+  }
+  const playerBeads = Object.values(state.beads).filter((b) => b.ownerId === playerId);
+  if (playerBeads.length === 0) return 0;
+  let unique = 0;
+  let total = 0;
+  for (const bead of playerBeads) {
+    const sh = shingles(bead.content);
+    total += sh.length;
+    for (const s of sh) {
+      if ((counts.get(s) || 0) === 1) unique++;
+    }
+  }
+  return total === 0 ? 0 : unique / total;
 }

--- a/apps/server/src/judge/resonance.ts
+++ b/apps/server/src/judge/resonance.ts
@@ -1,4 +1,31 @@
-// Resonance scoring favors boards with denser connections.
-export function score({ beadCount, edgeCount }: { beadCount: number; edgeCount: number }): number {
-  return Math.min(1, (edgeCount / Math.max(1, beadCount)) * 0.6 + 0.2);
+import type { GameState } from '@gbg/types';
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function jaccard(a: string[], b: string[]): number {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter((x) => setB.has(x));
+  const union = new Set([...a, ...b]);
+  return union.size === 0 ? 0 : intersection.length / union.size;
+}
+
+/**
+ * Resonance measures semantic cohesion between connected beads using a
+ * lightweight embedding approximation via token overlap.
+ */
+export function score(state: GameState, playerId: string): number {
+  const edges = Object.values(state.edges).filter(
+    (e) => state.beads[e.from]?.ownerId === playerId || state.beads[e.to]?.ownerId === playerId
+  );
+  if (edges.length === 0) return 0;
+  let total = 0;
+  for (const e of edges) {
+    const a = tokenize(state.beads[e.from]?.content || '');
+    const b = tokenize(state.beads[e.to]?.content || '');
+    total += jaccard(a, b);
+  }
+  return total / edges.length;
 }

--- a/apps/server/test/judge-scores.test.ts
+++ b/apps/server/test/judge-scores.test.ts
@@ -5,12 +5,58 @@ import { score as novelty } from '../src/judge/novelty.ts';
 import { score as integrity } from '../src/judge/integrity.ts';
 import { score as aesthetics } from '../src/judge/aesthetics.ts';
 import { score as resilience } from '../src/judge/resilience.ts';
+import type { GameState } from '@gbg/types';
 
-test('resonance handles edge ratios', () => {
-  assert.equal(resonance({ beadCount: 0, edgeCount: 0 }), 0.2);
-  assert.equal(resonance({ beadCount: 2, edgeCount: 10 }), 1);
-  const mid = resonance({ beadCount: 5, edgeCount: 3 });
-  assert.ok(mid > 0.2 && mid < 1);
+test('resonance higher for similar content', () => {
+  const makeState = (a: string, b: string): GameState => ({
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: a, complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p', modality: 'text', content: b, complexity: 1, createdAt: 0 }
+    },
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: '' } }
+  });
+  const sim = makeState('hello world', 'hello there');
+  const dis = makeState('foo', 'bar');
+  assert.ok(resonance(sim, 'p') > resonance(dis, 'p'));
+});
+
+test('novelty rewards rare shingles', () => {
+  const unique: GameState = {
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: { a: { id: 'a', ownerId: 'p', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 } },
+    edges: {}
+  };
+  const duplicate: GameState = {
+    ...unique,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'q', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 }
+    }
+  };
+  assert.ok(novelty(unique, 'p') > novelty(duplicate, 'p'));
+});
+
+test('integrity penalizes negations', () => {
+  const base: GameState = {
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: 'x', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p', modality: 'text', content: 'y', complexity: 1, createdAt: 0 }
+    },
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: 'This is good.' } }
+  };
+  const neg: GameState = {
+    ...base,
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: 'This is not good.' } }
+  };
+  assert.ok(integrity(base, 'p') > integrity(neg, 'p'));
 });
 
 test('resilience constant baseline', () => {
@@ -18,20 +64,8 @@ test('resilience constant baseline', () => {
   assert.equal(resilience({ beadCount: 10, edgeCount: 20 }), 0.5);
 });
 
-test('novelty grows with bead count', () => {
-  assert.equal(novelty({ beadCount: 0 }), 0.4);
-  const many = novelty({ beadCount: 20 });
-  assert.ok(many > 0.49 && many <= 0.5);
-});
-
 test('aesthetics rewards more beads', () => {
   assert.equal(aesthetics({ beadCount: 0 }), 0.2);
   assert.equal(aesthetics({ beadCount: 5 }), 0.55);
   assert.equal(aesthetics({ beadCount: 20 }), 1);
-});
-
-test('integrity increases with edges', () => {
-  assert.equal(integrity({ edgeCount: 0 }), 0.5);
-  const many = integrity({ edgeCount: 10 });
-  assert.ok(many > 0.59 && many < 0.6);
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const [handle, setHandle] = useState<string>(() => localStorage.getItem("handle") || "");
   const [playerId, setPlayerId] = useState<string>("");
   const [scroll, setScroll] = useState<JudgmentScroll | null>(null);
+  const [selectedPath, setSelectedPath] = useState<number>(0);
   const [beadText, setBeadText] = useState("");
   const { state, setState, connect } = useMatchState(undefined, { autoConnect: false });
   const currentPlayer = state?.players.find(p => p.id === state.currentPlayerId);
@@ -155,6 +156,7 @@ export default function App() {
       const res = await api(`/match/${state.id}/judge`, { method: "POST" });
       const data = (await res.json()) as JudgmentScroll;
       setScroll(data);
+      setSelectedPath(0);
     } catch (err) {
       console.error("Failed to request judgment", err);
     }
@@ -282,7 +284,7 @@ export default function App() {
             <section className="lg:col-span-2">
               <h3 className="text-sm uppercase tracking-wide text-[var(--muted)]">Graph</h3>
               <div className="mt-2">
-                <GraphView matchId={matchId} strongPaths={scroll?.strongPaths} width={600} height={400} />
+                <GraphView matchId={matchId} strongPaths={scroll?.strongPaths} selectedPathIndex={selectedPath} width={600} height={400} />
               </div>
             </section>
           </div>
@@ -290,16 +292,36 @@ export default function App() {
         {scroll && (
           <section className="mt-6">
             <h3 className="text-sm uppercase tracking-wide text-[var(--muted)]">Judgment</h3>
-            <div className="mt-2 text-sm">
-              <div className="mb-2">Winner: {scroll.winner || "TBD"}</div>
-              <ul className="space-y-1">
-                {Object.entries(scroll.scores).map(([pid, s]) => (
-                  <li key={pid} className="text-xs">
-                    <b>{pid}</b>: {(s.total * 100).toFixed(1)}% (res {s.resonance.toFixed(2)}, nov {s.novelty.toFixed(2)}, int {s.integrity.toFixed(2)})
-                  </li>
-                ))}
-              </ul>
-            </div>
+              <div className="mt-2 text-sm">
+                <div className="mb-2">Winner: {scroll.winner || "TBD"}</div>
+                <ul className="space-y-1">
+                  {Object.entries(scroll.scores).map(([pid, s]) => (
+                    <li key={pid} className="text-xs">
+                      <b>{pid}</b>: {(s.total * 100).toFixed(1)}% (res {s.resonance.toFixed(2)}, nov {s.novelty.toFixed(2)}, int {s.integrity.toFixed(2)}, aes {s.aesthetics.toFixed(2)}, res {s.resilience.toFixed(2)})
+                    </li>
+                  ))}
+                </ul>
+                {scroll.strongPaths.length > 0 && (
+                  <div className="mt-4">
+                    <h4 className="text-xs uppercase tracking-wide text-[var(--muted)]">Strong Paths</h4>
+                    <ul className="mt-1 space-y-1">
+                      {scroll.strongPaths.map((p, idx) => (
+                        <li key={idx}>
+                          <button onClick={() => setSelectedPath(idx)} className={`text-xs underline ${selectedPath === idx ? 'font-bold' : ''}`}>
+                            {p.nodes.join(' → ')} {p.why && `(${p.why})`}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {scroll.weakSpots.length > 0 && (
+                  <div className="mt-4">
+                    <h4 className="text-xs uppercase tracking-wide text-[var(--muted)]">Weak Spots</h4>
+                    <div className="text-xs">{scroll.weakSpots.join(', ')}</div>
+                  </div>
+                )}
+              </div>
           </section>
         )}
       </main>

--- a/packages/types/test/resonance.test.ts
+++ b/packages/types/test/resonance.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { GraphState, addBead, addEdge, findStrongestPaths } from "../src/index.ts";
+import type { GameState } from "../src/index.ts";
 import { score as resonanceScore } from "../../../apps/server/src/judge/resonance.ts";
 
 test("findStrongestPaths returns heaviest paths", () => {
@@ -18,8 +19,26 @@ test("findStrongestPaths returns heaviest paths", () => {
   assert.ok(paths[0].weight > (paths[1]?.weight ?? -Infinity));
 });
 
-test("resonance score favors edge density", () => {
-  const low = resonanceScore({ beadCount: 2, edgeCount: 1 });
-  const high = resonanceScore({ beadCount: 2, edgeCount: 2 });
+test("resonance score favors semantic similarity", () => {
+  const makeState = (a: string, b: string): GameState => ({
+    id: "m",
+    round: 1,
+    phase: "",
+    players: [{ id: "p", handle: "h", resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: "p",
+    seeds: [],
+    beads: {
+      a: { id: "a", ownerId: "p", modality: "text", content: a, complexity: 1, createdAt: 0 },
+      b: { id: "b", ownerId: "p", modality: "text", content: b, complexity: 1, createdAt: 0 },
+    },
+    edges: { e: { id: "e", from: "a", to: "b", label: "analogy", justification: "" } },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+  const similar = makeState("hello world", "hello there");
+  const dissimilar = makeState("foo", "bar");
+  const high = resonanceScore(similar, "p");
+  const low = resonanceScore(dissimilar, "p");
   assert.ok(high > low);
 });


### PR DESCRIPTION
## Summary
- score resonance by token-level similarity of connected beads
- flag negated justifications for integrity and reward rare shingles for novelty
- compute strong paths & weak spots and surface per-axis scores and path inspection in UI

## Testing
- `npm --workspace packages/types test`
- `npm test` *(fails: fetch failed in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaa69f030832c89c1da61a26b1328