### PR TITLE
Add player ratings and ladder component

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ await fastify.register(cors, { origin: true });
 const matches = new Map<string, GameState>();
 const sockets = new Map<string, Set<WebSocket>>();
 const metrics = { wsSendFailures: 0, totalMoves: 0, latency: 0 };
+const ratings = new Map<string, { wins: number; losses: number }>();
 
 // --- Utility
 function now(){ return Date.now(); }
@@ -146,10 +147,33 @@ fastify.post<{ Params: { id: string } }>("/match/:id/judge", async (req, reply) 
   const useLlm = !!process.env.LLM_MODEL;
   const scroll = useLlm ? await judgeWithLLM(state) : judge(state);
   broadcast(id, "end:judgment", scroll);
+  const winnerId = scroll.winner;
+  if (winnerId) {
+    for (const p of state.players) {
+      const rec = ratings.get(p.handle) || { wins: 0, losses: 0 };
+      if (p.id === winnerId) rec.wins++; else rec.losses++;
+      ratings.set(p.handle, rec);
+    }
+  }
   return reply.send(scroll);
 });
 
 fastify.get("/metrics", async () => metrics);
+
+fastify.get("/ratings", async () => {
+  return Array.from(ratings.entries()).map(([handle, rec]) => ({ handle, ...rec }));
+});
+
+fastify.post<{ Body: { handle: string; result: "win" | "loss" } }>("/ratings", async (req, reply) => {
+  const { handle, result } = req.body;
+  if (!handle || (result !== "win" && result !== "loss")) {
+    return reply.code(400).send({ error: "Invalid rating update" });
+  }
+  const rec = ratings.get(handle) || { wins: 0, losses: 0 };
+  if (result === "win") rec.wins++; else rec.losses++;
+  ratings.set(handle, rec);
+  return reply.send({ handle, ...rec });
+});
 
 // --- WebSocket (per match)
 const server = fastify.server;

--- a/apps/web/src/Ladder.test.tsx
+++ b/apps/web/src/Ladder.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import Ladder from './Ladder';
+
+describe('Ladder', () => {
+  beforeEach(() => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => [
+          { handle: 'Alice', wins: 2, losses: 1 },
+          { handle: 'Bob', wins: 1, losses: 2 },
+        ],
+      })
+    );
+  });
+
+  it('fetches and displays standings', async () => {
+    render(<Ladder />);
+    await waitFor(() => {
+      expect(screen.getByText(/#1 Alice/)).toBeInTheDocument();
+      expect(screen.getByText(/#2 Bob/)).toBeInTheDocument();
+    });
+  });
+});
+

--- a/apps/web/src/Ladder.tsx
+++ b/apps/web/src/Ladder.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+
+interface Rating {
+  handle: string;
+  wins: number;
+  losses: number;
+}
+
+export default function Ladder() {
+  const [standings, setStandings] = useState<Rating[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("http://localhost:8787/ratings");
+        if (!res.ok) return;
+        const data = await res.json();
+        setStandings(data);
+      } catch (err) {
+        console.warn("Failed to load ratings", err);
+      }
+    }
+    load();
+  }, []);
+
+  const sorted = [...standings].sort((a, b) => b.wins - a.wins);
+
+  return (
+    <div>
+      <h2 className="text-lg font-medium mb-2">Ladder</h2>
+      <ol className="space-y-1">
+        {sorted.map((r, idx) => (
+          <li key={r.handle} className="text-sm">
+            #{idx + 1} {r.handle} — {r.wins}W-{r.losses}L
+          </li>
+        ))}
+        {sorted.length === 0 && (
+          <li className="text-sm opacity-60">No standings yet</li>
+        )}
+      </ol>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- track wins/losses with in-memory ratings store and REST endpoints
- update ratings when matches are judged
- add Ladder component to display standings

## Testing
- `npm --workspace packages/types run test`
- `npm --workspace apps/web run test`
- `npm --workspace apps/server run test` *(fails: fetch failed to connect)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaa6b6f5c832cabf623c5c477dc1f