### PR TITLE
feat: support prune moves

### DIFF
--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -45,6 +45,11 @@ export default function registerMoveRoute(
             move.payload.justification
           );
         }
+      } else if (move.type === "prune") {
+        const { beadId, edgeId } = move.payload ?? {};
+        move.payload = {};
+        if (typeof beadId === "string") move.payload.beadId = beadId;
+        if (typeof edgeId === "string") move.payload.edgeId = edgeId;
       }
       const validation = validateMove(move, state);
       if (!validation.ok) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -135,6 +135,48 @@ export default function App() {
     }
   };
 
+  const pruneBead = async (beadId: string) => {
+    if (!playerId || !state) return;
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "prune",
+      payload: { beadId },
+      timestamp: Date.now(),
+      durationMs: 500,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+    } catch (err) {
+      console.error("Failed to prune bead", err);
+    }
+  };
+
+  const pruneEdge = async (edgeId: string) => {
+    if (!playerId || !state) return;
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "prune",
+      payload: { edgeId },
+      timestamp: Date.now(),
+      durationMs: 500,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+    } catch (err) {
+      console.error("Failed to prune edge", err);
+    }
+  };
+
   const suggestBead = async () => {
     if (!state || !playerId) return;
     try {
@@ -259,8 +301,23 @@ export default function App() {
                       selected.includes(b.id) ? "ring-2 ring-indigo-500" : ""
                     }`}
                   >
-                    <div className="text-sm font-semibold">{b.title || b.id}</div>
-                    <div className="text-xs opacity-70">{b.modality} · by {b.ownerId}</div>
+                    <div className="flex justify-between items-start">
+                      <div>
+                        <div className="text-sm font-semibold">{b.title || b.id}</div>
+                        <div className="text-xs opacity-70">{b.modality} · by {b.ownerId}</div>
+                      </div>
+                      {isMyTurn && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            pruneBead(b.id);
+                          }}
+                          className="text-xs text-red-400 hover:text-red-200"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </div>
                     <div className="text-xs mt-1 opacity-80">{tryParseMarkdown(b.content)}</div>
                   </li>
                 ))}
@@ -271,8 +328,18 @@ export default function App() {
               <ul className="mt-2 space-y-2">
                 {Object.values(state.edges).map((e) => (
                   <li key={e.id} className="p-3 rounded bg-zinc-900 text-xs">
-                    <div className="opacity-80">
-                      <b>{e.label}</b>: {e.from} → {e.to}
+                    <div className="flex justify-between">
+                      <div className="opacity-80">
+                        <b>{e.label}</b>: {e.from} → {e.to}
+                      </div>
+                      {isMyTurn && (
+                        <button
+                          onClick={() => pruneEdge(e.id)}
+                          className="text-red-400 hover:text-red-200"
+                        >
+                          Remove
+                        </button>
+                      )}
                     </div>
                     <div className="opacity-60 mt-1">{e.justification}</div>
                   </li>

--- a/packages/types/test/validation.test.ts
+++ b/packages/types/test/validation.test.ts
@@ -151,6 +151,53 @@ test('validateMove bind success and failure', () => {
   assert.equal(validateMove(invalidBind, state).ok, false);
 });
 
+test('validateMove prune success and failure', () => {
+  const bead1: Bead = {
+    id: 'b1',
+    ownerId: 'p1',
+    modality: 'text',
+    content: 'a',
+    complexity: 1,
+    createdAt: 0,
+  };
+  const state: GameState = {
+    id: 'g1',
+    round: 1,
+    phase: 'play',
+    players: [
+      { id: 'p1', handle: 'P1', resources: { insight: 1, restraint: 1, wildAvailable: false } },
+    ],
+    seeds: [],
+    beads: { b1: bead1 },
+    edges: {},
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const valid: Move = {
+    id: 'm1',
+    playerId: 'p1',
+    type: 'prune',
+    payload: { beadId: 'b1' },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(valid, state).ok, true);
+
+  const invalid: Move = {
+    id: 'm2',
+    playerId: 'p1',
+    type: 'prune',
+    payload: {},
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(invalid, state).ok, false);
+});
+
 test('applyMove mutates state for cast and bind', () => {
   const bead2: Bead = {
     id: 'b2',
@@ -337,5 +384,43 @@ test('applyMoveWithResources deducts resources and uses wild', () => {
   applyMoveWithResources(state, bind2);
   assert.equal(state.players[1].resources.restraint, 0);
   assert.equal(state.players[1].resources.wildAvailable, false);
+});
+
+test('applyMoveWithResources prunes beads and edges', () => {
+  const bead1: Bead = {
+    id: 'b1', ownerId: 'p1', modality: 'text', content: 'one', complexity: 1, createdAt: 0,
+  };
+  const bead2: Bead = {
+    id: 'b2', ownerId: 'p2', modality: 'text', content: 'two', complexity: 1, createdAt: 0,
+  };
+  const state: GameState = {
+    id: 'g1', round: 1, phase: 'play',
+    players: [
+      { id: 'p1', handle: 'P1', resources: { insight: 0, restraint: 0, wildAvailable: true } },
+      { id: 'p2', handle: 'P2', resources: { insight: 0, restraint: 1, wildAvailable: true } },
+    ],
+    seeds: [],
+    beads: { b1: bead1, b2: bead2 },
+    edges: {
+      e1: { id: 'e1', from: 'b1', to: 'b2', label: 'analogy', justification: 'First. Second.' },
+    },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const prune: Move = {
+    id: 'p1',
+    playerId: 'p2',
+    type: 'prune',
+    payload: { beadId: 'b1' },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  applyMoveWithResources(state, prune);
+  assert.equal(state.beads['b1'], undefined);
+  assert.equal(state.edges['e1'], undefined);
+  assert.equal(state.players[1].resources.restraint, 0);
 });
 


### PR DESCRIPTION
## Summary
- add validation and state updates for prune moves with resource costs
- handle prune requests on server
- allow pruning beads and edges in the web UI

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfaa6d5200832ca4c44b80a5ea1ab3