### PR TITLE
feat: add cathedral canonization

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm --workspace @gbg/types run build && npm run build",
     "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import {
   Player,
   Move,
   sanitizeMarkdown,
+  ConstraintCard,
 } from "@gbg/types";
 import registerMoveRoute from "./routes/move.js";
 import judge from "./judge/index.js";
@@ -32,6 +33,29 @@ function sampleSeeds(): GameState["seeds"]{
     {id:"s3", text:"Amnesty", domain:"civics"}
   ];
   return seeds;
+}
+
+function sampleTwists(): ConstraintCard[]{
+  return [
+    {
+      id: 't1',
+      name: 'Text Only',
+      description: 'Only text beads allowed',
+      effect: { modalityLock: ['text'] }
+    },
+    {
+      id: 't2',
+      name: 'Motif Echo',
+      description: 'Relations must be motif-echo',
+      effect: { requiredRelation: 'motif-echo' }
+    },
+    {
+      id: 't3',
+      name: 'Short Justification',
+      description: 'Justifications capped at 40 chars',
+      effect: { justificationLimit: 40 }
+    }
+  ];
 }
 function broadcast(matchId: string, type: string, payload: any){
   const set = sockets.get(matchId); if(!set) return;
@@ -74,7 +98,13 @@ fastify.post("/match", async (req, reply) => {
   const id = randomUUID().slice(0,8);
   const state: GameState = {
     id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds: sampleSeeds(),
-    beads: {}, edges: {}, moves: [], cathedral: undefined, createdAt: now(), updatedAt: now()
+    beads: {},
+    edges: {},
+    moves: [],
+    twistDeck: sampleTwists(),
+    cathedral: undefined,
+    createdAt: now(),
+    updatedAt: now()
   };
   matches.set(id, state);
   return reply.send(state);
@@ -113,6 +143,18 @@ fastify.get<{ Params: { id: string } }>("/match/:id/log", async (req, reply) => 
     .header("Content-Type", "application/json")
     .header("Content-Disposition", `attachment; filename=match-${state.id}.json`);
   return reply.send(state);
+});
+
+fastify.post<{ Params: { id: string } }>("/match/:id/twist", async (req, reply) => {
+  const id = req.params.id;
+  const state = matches.get(id);
+  if(!state) return reply.code(404).send({ error: "No such match" });
+  const next = state.twistDeck?.shift();
+  if(!next) return reply.code(400).send({ error: "No twists remaining" });
+  state.twist = next;
+  state.updatedAt = now();
+  broadcast(id, "state:update", state);
+  return reply.send(next);
 });
 
 registerMoveRoute(fastify, { matches, broadcast, now, logMetrics });

--- a/apps/server/src/judge/integrity.ts
+++ b/apps/server/src/judge/integrity.ts
@@ -1,3 +1,19 @@
-export function score({ edgeCount }: { edgeCount: number }): number {
-  return 0.5 + 0.1 * Math.tanh(edgeCount / 5);
+import type { GameState } from '@gbg/types';
+
+const CONTRADICTION_RE = /\b(?:not|no|never|n't)\b/i;
+
+/**
+ * Integrity penalizes edges whose justifications contain explicit
+ * contradictions or negations, approximating an NLI check.
+ */
+export function score(state: GameState, playerId: string): number {
+  const edges = Object.values(state.edges).filter(
+    (e) => state.beads[e.from]?.ownerId === playerId || state.beads[e.to]?.ownerId === playerId
+  );
+  if (edges.length === 0) return 1;
+  let contradictions = 0;
+  for (const e of edges) {
+    if (CONTRADICTION_RE.test(e.justification)) contradictions++;
+  }
+  return 1 - contradictions / edges.length;
 }

--- a/apps/server/src/judge/novelty.ts
+++ b/apps/server/src/judge/novelty.ts
@@ -1,3 +1,34 @@
-export function score({ beadCount }: { beadCount: number }): number {
-  return 0.4 + 0.1 * Math.tanh(beadCount / 4);
+import type { GameState } from '@gbg/types';
+
+function shingles(text: string, size = 3): string[] {
+  const tokens = text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  const result: string[] = [];
+  for (let i = 0; i <= tokens.length - size; i++) {
+    result.push(tokens.slice(i, i + size).join(' '));
+  }
+  return result;
+}
+
+/**
+ * Novelty rewards beads whose shingles (n-grams) are rare across the board.
+ */
+export function score(state: GameState, playerId: string): number {
+  const counts = new Map<string, number>();
+  for (const bead of Object.values(state.beads)) {
+    for (const s of shingles(bead.content)) {
+      counts.set(s, (counts.get(s) || 0) + 1);
+    }
+  }
+  const playerBeads = Object.values(state.beads).filter((b) => b.ownerId === playerId);
+  if (playerBeads.length === 0) return 0;
+  let unique = 0;
+  let total = 0;
+  for (const bead of playerBeads) {
+    const sh = shingles(bead.content);
+    total += sh.length;
+    for (const s of sh) {
+      if ((counts.get(s) || 0) === 1) unique++;
+    }
+  }
+  return total === 0 ? 0 : unique / total;
 }

--- a/apps/server/src/judge/resonance.ts
+++ b/apps/server/src/judge/resonance.ts
@@ -1,4 +1,31 @@
-// Resonance scoring favors boards with denser connections.
-export function score({ beadCount, edgeCount }: { beadCount: number; edgeCount: number }): number {
-  return Math.min(1, (edgeCount / Math.max(1, beadCount)) * 0.6 + 0.2);
+import type { GameState } from '@gbg/types';
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function jaccard(a: string[], b: string[]): number {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter((x) => setB.has(x));
+  const union = new Set([...a, ...b]);
+  return union.size === 0 ? 0 : intersection.length / union.size;
+}
+
+/**
+ * Resonance measures semantic cohesion between connected beads using a
+ * lightweight embedding approximation via token overlap.
+ */
+export function score(state: GameState, playerId: string): number {
+  const edges = Object.values(state.edges).filter(
+    (e) => state.beads[e.from]?.ownerId === playerId || state.beads[e.to]?.ownerId === playerId
+  );
+  if (edges.length === 0) return 0;
+  let total = 0;
+  for (const e of edges) {
+    const a = tokenize(state.beads[e.from]?.content || '');
+    const b = tokenize(state.beads[e.to]?.content || '');
+    total += jaccard(a, b);
+  }
+  return total / edges.length;
 }

--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -31,7 +31,7 @@ export default function registerMoveRoute(
 
       const move = (req.body as any) as Move;
       // sanitize text fields
-      if (move.type === "cast") {
+      if (move.type === "cast" || move.type === "mirror") {
         const bead = move.payload?.bead as Bead;
         if (bead) {
           bead.content = sanitizeMarkdown(bead.content);
@@ -39,7 +39,7 @@ export default function registerMoveRoute(
             bead.title = sanitizeMarkdown(bead.title);
           }
         }
-      } else if (move.type === "bind") {
+      } else if (move.type === "bind" || move.type === "counterpoint") {
         if (typeof move.payload?.justification === "string") {
           move.payload.justification = sanitizeMarkdown(
             move.payload.justification

--- a/apps/server/test/judge-scores.test.ts
+++ b/apps/server/test/judge-scores.test.ts
@@ -5,12 +5,58 @@ import { score as novelty } from '../src/judge/novelty.ts';
 import { score as integrity } from '../src/judge/integrity.ts';
 import { score as aesthetics } from '../src/judge/aesthetics.ts';
 import { score as resilience } from '../src/judge/resilience.ts';
+import type { GameState } from '@gbg/types';
 
-test('resonance handles edge ratios', () => {
-  assert.equal(resonance({ beadCount: 0, edgeCount: 0 }), 0.2);
-  assert.equal(resonance({ beadCount: 2, edgeCount: 10 }), 1);
-  const mid = resonance({ beadCount: 5, edgeCount: 3 });
-  assert.ok(mid > 0.2 && mid < 1);
+test('resonance higher for similar content', () => {
+  const makeState = (a: string, b: string): GameState => ({
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: a, complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p', modality: 'text', content: b, complexity: 1, createdAt: 0 }
+    },
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: '' } }
+  });
+  const sim = makeState('hello world', 'hello there');
+  const dis = makeState('foo', 'bar');
+  assert.ok(resonance(sim, 'p') > resonance(dis, 'p'));
+});
+
+test('novelty rewards rare shingles', () => {
+  const unique: GameState = {
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: { a: { id: 'a', ownerId: 'p', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 } },
+    edges: {}
+  };
+  const duplicate: GameState = {
+    ...unique,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'q', modality: 'text', content: 'alpha beta gamma', complexity: 1, createdAt: 0 }
+    }
+  };
+  assert.ok(novelty(unique, 'p') > novelty(duplicate, 'p'));
+});
+
+test('integrity penalizes negations', () => {
+  const base: GameState = {
+    id: 'm', round: 1, phase: '',
+    players: [{ id: 'p', handle: 'h', resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: 'p', seeds: [], moves: [], createdAt: 0, updatedAt: 0,
+    beads: {
+      a: { id: 'a', ownerId: 'p', modality: 'text', content: 'x', complexity: 1, createdAt: 0 },
+      b: { id: 'b', ownerId: 'p', modality: 'text', content: 'y', complexity: 1, createdAt: 0 }
+    },
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: 'This is good.' } }
+  };
+  const neg: GameState = {
+    ...base,
+    edges: { e: { id: 'e', from: 'a', to: 'b', label: 'analogy', justification: 'This is not good.' } }
+  };
+  assert.ok(integrity(base, 'p') > integrity(neg, 'p'));
 });
 
 test('resilience constant baseline', () => {
@@ -18,20 +64,8 @@ test('resilience constant baseline', () => {
   assert.equal(resilience({ beadCount: 10, edgeCount: 20 }), 0.5);
 });
 
-test('novelty grows with bead count', () => {
-  assert.equal(novelty({ beadCount: 0 }), 0.4);
-  const many = novelty({ beadCount: 20 });
-  assert.ok(many > 0.49 && many <= 0.5);
-});
-
 test('aesthetics rewards more beads', () => {
   assert.equal(aesthetics({ beadCount: 0 }), 0.2);
   assert.equal(aesthetics({ beadCount: 5 }), 0.55);
   assert.equal(aesthetics({ beadCount: 20 }), 1);
-});
-
-test('integrity increases with edges', () => {
-  assert.equal(integrity({ edgeCount: 0 }), 0.5);
-  const many = integrity({ edgeCount: 10 });
-  assert.ok(many > 0.59 && many < 0.6);
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,16 @@
 import sanitizeHtml from "sanitize-html";
 
+export type { GraphState } from "./graph.js";
+export {
+  addBead,
+  addEdge,
+  removeEdge,
+  neighbors,
+  longestPathFrom,
+  maxWeightedPathFrom,
+  findStrongestPaths,
+} from "./graph.js";
+
 export type Modality = "text" | "image" | "audio" | "math" | "code" | "data";
 export type RelationLabel =
   | "analogy" | "isomorphism" | "duality" | "causality" | "symmetry" | "inverse"
@@ -18,7 +29,17 @@ export interface Bead {
 export interface Edge {
   id: string; from: string; to: string; label: RelationLabel; justification: string;
 }
-export type MoveType = "cast" | "bind" | "transmute" | "lift" | "refute" | "canonize" | "prune" | "mirror" | "joker";
+export type MoveType =
+  | "cast"
+  | "bind"
+  | "transmute"
+  | "lift"
+  | "refute"
+  | "canonize"
+  | "prune"
+  | "mirror"
+  | "counterpoint"
+  | "joker";
 export interface Move {
   id: string; playerId: string; type: MoveType; payload: any;
   timestamp: number; durationMs: number; valid: boolean; notes?: string;
@@ -49,7 +70,11 @@ export interface GameState {
   id: string; round: 1|2|3|4; phase: string; players: Player[];
   currentPlayerId?: string;
   seeds: Seed[]; beads: Record<string,Bead>; edges: Record<string,Edge>; moves: Move[];
-  twist?: ConstraintCard; cathedral?: Cathedral; createdAt: number; updatedAt: number;
+  /** Active twist affecting move validation */
+  twist?: ConstraintCard;
+  /** Remaining twists to draw from */
+  twistDeck?: ConstraintCard[];
+  cathedral?: Cathedral; createdAt: number; updatedAt: number;
 }
 
 export interface JudgedScores {
@@ -117,7 +142,7 @@ export function validateSeed(seed: Seed): boolean {
 
 /**
  * Validate a move against a given game state. Currently supports basic rules for
- * `cast` and `bind` moves.
+ * `cast`, `bind`, `mirror`, and `counterpoint` moves.
  */
 export interface ValidationResult { ok: boolean; error?: string }
 
@@ -130,6 +155,7 @@ const MOVE_COSTS: Record<MoveType, { insight?: number; restraint?: number }> = {
   canonize: { insight: 1, restraint: 1 },
   prune: { restraint: 1 },
   mirror: { insight: 1 },
+  counterpoint: { insight: 1 },
   joker: {}
 };
 
@@ -149,12 +175,13 @@ export function validateMove(move: Move, state: GameState): ValidationResult {
     if (restraintShort) return { ok: false, error: "Not enough restraint" };
   }
 
-  if (move.type === "cast") {
+  const twist = state.twist?.effect;
+
+  if (move.type === "cast" || move.type === "mirror") {
     const bead = move.payload?.bead as Bead | undefined;
     if (!bead) return { ok: false, error: "Missing bead" };
-    if (bead.modality !== "text") return { ok: false, error: "Only text beads allowed" };
-    if (typeof bead.content !== "string") return { ok: false, error: "Invalid content" };
-    if (bead.content.trim().length === 0) return { ok: false, error: "Empty content" };
+    if (typeof bead.content !== "string" || bead.content.trim().length === 0)
+      return { ok: false, error: "Empty content" };
     bead.content = sanitizeMarkdown(bead.content);
     if (bead.content.length > 10_000) return { ok: false, error: "Content too long" };
     if (typeof bead.complexity !== "number" || bead.complexity < 1 || bead.complexity > 5)
@@ -165,17 +192,38 @@ export function validateMove(move: Move, state: GameState): ValidationResult {
     }
     if (bead.seedId && !state.seeds.find((s) => s.id === bead.seedId))
       return { ok: false, error: "Unknown seed" };
+    // Mirror-specific: ensure target exists and modality differs
+    if (move.type === "mirror") {
+      const targetId = move.payload?.targetId as string | undefined;
+      if (!targetId || !state.beads[targetId])
+        return { ok: false, error: "Target bead not found" };
+      const target = state.beads[targetId];
+      if (target.modality === bead.modality)
+        return { ok: false, error: "Must change modality" };
+    } else {
+      // cast move restrictions
+      if (bead.modality !== "text")
+        return { ok: false, error: "Only text beads allowed" };
+    }
+    if (twist?.modalityLock && !twist.modalityLock.includes(bead.modality))
+      return { ok: false, error: "Twist restricts modality" };
     return { ok: true };
   }
 
-  if (move.type === "bind") {
+  if (move.type === "bind" || move.type === "counterpoint") {
     const { from, to, label, justification } = move.payload ?? {};
     if (!from || !to || from === to) return { ok: false, error: "Invalid endpoints" };
     if (!state.beads[from] || !state.beads[to]) return { ok: false, error: "Bead not found" };
-    if (label !== "analogy") return { ok: false, error: "Unsupported relation" };
+    if (move.type === "bind" && label !== "analogy")
+      return { ok: false, error: "Unsupported relation" };
+    if (typeof label !== "string") return { ok: false, error: "Missing relation" };
+    if (twist?.requiredRelation && label !== twist.requiredRelation)
+      return { ok: false, error: `Twist requires relation ${twist.requiredRelation}` };
     if (typeof justification !== "string" || justification.trim().length === 0)
       return { ok: false, error: "Missing justification" };
     const cleanJust = sanitizeMarkdown(justification);
+    if (twist?.justificationLimit && cleanJust.length > twist.justificationLimit)
+      return { ok: false, error: "Justification too long" };
     move.payload.justification = cleanJust;
     const sentences = cleanJust
       .split(/[.!?]/)
@@ -198,20 +246,21 @@ export function validateMove(move: Move, state: GameState): ValidationResult {
     return { ok: true };
   }
 
-  return { ok: true }; // other move types are treated as valid for now
+  return { ok: true }; // other move types treated as valid
 }
 /**
- * Apply a move to mutate the given game state. Supports basic `cast` and `bind` moves.
+ * Apply a move to mutate the given game state. Supports basic `cast`, `bind`, `mirror`,
+ * and `counterpoint` moves.
  * Assumes the move has already been validated.
  */
 export function applyMove(state: GameState, move: Move): void {
   state.moves.push(move);
-  if (move.type === "cast") {
+  if (move.type === "cast" || move.type === "mirror") {
     const bead = move.payload?.bead as Bead | undefined;
     if (bead) {
       state.beads[bead.id] = bead;
     }
-  } else if (move.type === "bind") {
+  } else if (move.type === "bind" || move.type === "counterpoint") {
     const { edgeId, from, to, label, justification } = move.payload ?? {};
     const id = edgeId ?? move.id;
     const edge: Edge = { id, from, to, label, justification };

--- a/packages/types/test/resonance.test.ts
+++ b/packages/types/test/resonance.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { GraphState, addBead, addEdge, findStrongestPaths } from "../src/graph.ts";
+import type { GameState } from "../src/index.ts";
 import { score as resonanceScore } from "../../../apps/server/src/judge/resonance.ts";
 
 test("findStrongestPaths returns heaviest paths", () => {
@@ -18,8 +19,26 @@ test("findStrongestPaths returns heaviest paths", () => {
   assert.ok(paths[0].weight > (paths[1]?.weight ?? -Infinity));
 });
 
-test("resonance score favors edge density", () => {
-  const low = resonanceScore({ beadCount: 2, edgeCount: 1 });
-  const high = resonanceScore({ beadCount: 2, edgeCount: 2 });
+test("resonance score favors semantic similarity", () => {
+  const makeState = (a: string, b: string): GameState => ({
+    id: "m",
+    round: 1,
+    phase: "",
+    players: [{ id: "p", handle: "h", resources: { insight: 0, restraint: 0, wildAvailable: false } }],
+    currentPlayerId: "p",
+    seeds: [],
+    beads: {
+      a: { id: "a", ownerId: "p", modality: "text", content: a, complexity: 1, createdAt: 0 },
+      b: { id: "b", ownerId: "p", modality: "text", content: b, complexity: 1, createdAt: 0 },
+    },
+    edges: { e: { id: "e", from: "a", to: "b", label: "analogy", justification: "" } },
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  });
+  const similar = makeState("hello world", "hello there");
+  const dissimilar = makeState("foo", "bar");
+  const high = resonanceScore(similar, "p");
+  const low = resonanceScore(dissimilar, "p");
   assert.ok(high > low);
 });


### PR DESCRIPTION
## Summary
- resolve merge conflicts with `main`
- expose graph helpers from types package
- support twist deck alongside cathedral in server and web

## Testing
- `npm --workspace packages/types test`
- `npm --workspace apps/server test` *(fails: judge produces deterministic scores and winner)*
- `npm --workspace apps/web test` *(fails: Cannot find module './graph.js' from '../../packages/types/src/index.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68bfad4943e4832c9d9dcfedad299670