### PR TITLE
fix: include prune logic in applyMove

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -201,21 +201,13 @@ export function applyMove(state: GameState, move: Move): void {
     const id = edgeId ?? move.id;
     const edge: Edge = { id, from, to, label, justification };
     state.edges[id] = edge;
-  }
-  state.updatedAt = move.timestamp;
-}
-
-/** Apply a move and deduct resource costs from the acting player. */
-export function applyMoveWithResources(state: GameState, move: Move): void {
-  applyMove(state, move);
-  if (move.type === "prune") {
+  } else if (move.type === "prune") {
     const { beadId, edgeId } = move.payload ?? {};
     if (edgeId && state.edges[edgeId]) {
       delete state.edges[edgeId];
     }
     if (beadId && state.beads[beadId]) {
       delete state.beads[beadId];
-      // Remove edges connected to this bead
       for (const id of Object.keys(state.edges)) {
         const e = state.edges[id];
         if (e.from === beadId || e.to === beadId) {
@@ -224,6 +216,12 @@ export function applyMoveWithResources(state: GameState, move: Move): void {
       }
     }
   }
+  state.updatedAt = move.timestamp;
+}
+
+/** Apply a move and deduct resource costs from the acting player. */
+export function applyMoveWithResources(state: GameState, move: Move): void {
+  applyMove(state, move);
   const player = state.players.find((p) => p.id === move.playerId);
   if (!player) return;
   const cost = MOVE_COSTS[move.type] ?? {};


### PR DESCRIPTION
## Summary
- handle prune moves inside `applyMove` so history replay prunes beads and edges
- simplify `applyMoveWithResources` to only deduct resource costs

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace apps/server run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfada3a47c832cbe4a1499d79e33a0