### PR TITLE
Add ratings endpoint test and ladder error handling tests

### DIFF
--- a/apps/server/test/ratings.test.ts
+++ b/apps/server/test/ratings.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { startServer } from './server.helper.js';
+
+// Ensure server ratings endpoint aggregates standings correctly
+
+// Using unique port to avoid collisions
+const PORT = 9998;
+
+test('ratings endpoint aggregates standings', async (t) => {
+  const server = await startServer(PORT);
+  t.after(() => {
+    server.kill();
+  });
+  const base = `http://127.0.0.1:${PORT}`;
+
+  const post = (handle: string, result: 'win' | 'loss') =>
+    fetch(`${base}/ratings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle, result }),
+    });
+
+  // Record some results
+  await post('Alice', 'win');
+  await post('Bob', 'loss');
+  await post('Alice', 'loss');
+
+  const standingsRes = await fetch(`${base}/ratings`);
+  const standings = (await standingsRes.json()) as any[];
+
+  const alice = standings.find((r) => r.handle === 'Alice');
+  const bob = standings.find((r) => r.handle === 'Bob');
+
+  assert.deepEqual(alice, { handle: 'Alice', wins: 1, losses: 1 });
+  assert.deepEqual(bob, { handle: 'Bob', wins: 0, losses: 1 });
+});
+

--- a/apps/web/src/Ladder.test.tsx
+++ b/apps/web/src/Ladder.test.tsx
@@ -22,5 +22,26 @@ describe('Ladder', () => {
       expect(screen.getByText(/#2 Bob/)).toBeInTheDocument();
     });
   });
+
+  it('shows empty message when no standings', async () => {
+    (global.fetch as any) = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => [] })
+    );
+    render(<Ladder />);
+    await waitFor(() => {
+      expect(screen.getByText(/No standings yet/)).toBeInTheDocument();
+    });
+  });
+
+  it('handles fetch failure gracefully', async () => {
+    (global.fetch as any) = jest.fn(() => Promise.reject(new Error('fail')));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<Ladder />);
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalled();
+      expect(screen.getByText(/No standings yet/)).toBeInTheDocument();
+    });
+    warn.mockRestore();
+  });
 });
 


### PR DESCRIPTION
## Summary
- verify ratings endpoint aggregates standings
- test ladder component for empty and failed fetch scenarios

## Testing
- `npm test --workspace apps/server` (fails: judge produces deterministic scores and winner)
- `npm test --workspace apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68c020428a78832cb8f5934f54c893b1