### PR TITLE
test: enforce twist constraints

### DIFF
--- a/apps/server/test/twist.test.ts
+++ b/apps/server/test/twist.test.ts
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function startServer(port: number){
+  const cwd = path.join(__dirname, '..');
+  const server = spawn('node', ['dist/index.js'], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore','pipe','pipe']
+  });
+  return server;
+}
+
+test('twist rejects bind with wrong relation', async (t) => {
+  const port = 9997;
+  const server = startServer(port);
+  await new Promise(r => setTimeout(r, 1000));
+  t.after(() => server.kill());
+  const base = `http://localhost:${port}`;
+
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('A');
+  await join('B');
+
+  const castBead = async (id:string) => {
+    const bead = { id, ownerId: p1.id, modality: 'text', content: 'x', complexity:1, createdAt: Date.now() };
+    const move = { id:`m_${Math.random().toString(36).slice(2,8)}`, playerId:p1.id, type:'cast', payload:{ bead }, timestamp:Date.now(), durationMs:0, valid:true };
+    await fetch(`${base}/match/${matchId}/move`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(move) });
+  };
+
+  const b1 = `b_${Math.random().toString(36).slice(2,8)}`;
+  const b2 = `b_${Math.random().toString(36).slice(2,8)}`;
+  await castBead(b1);
+  await castBead(b2);
+
+  // draw twists twice to reach requiredRelation twist
+  await fetch(`${base}/match/${matchId}/twist`, { method:'POST' });
+  await fetch(`${base}/match/${matchId}/twist`, { method:'POST' });
+
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2,8)}`,
+    playerId: p1.id,
+    type: 'bind',
+    payload: { from: b1, to: b2, label: 'analogy', justification: 'Alpha. Beta.' },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+  const res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Twist requires relation motif-echo');
+});
+

--- a/apps/web/src/Twist.test.tsx
+++ b/apps/web/src/Twist.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import App from './App';
+
+class MockWebSocket {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  static instances: MockWebSocket[] = [];
+  constructor(url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  close() {}
+}
+(global as any).WebSocket = MockWebSocket as any;
+
+const mockState = {
+  id: 'match1',
+  round: 1,
+  phase: 'play',
+  players: [{ id: 'player1', handle: 'Alice', resources: { insight: 0, restraint: 0, wildAvailable: true } }],
+  currentPlayerId: 'player1',
+  seeds: [{ id: 's1', text: 'Seed 1', domain: 'd1' }],
+  beads: {
+    b1: { id: 'b1', ownerId: 'player1', modality: 'text', title: 'Idea 1', content: 'One', complexity: 1, createdAt: 0, seedId: 's1' },
+    b2: { id: 'b2', ownerId: 'player1', modality: 'text', title: 'Idea 2', content: 'Two', complexity: 1, createdAt: 0, seedId: 's1' },
+  },
+  edges: {},
+  moves: [],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+describe('Twist UI', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    (global.fetch as any) = jest.fn((url: RequestInfo, opts?: RequestInit) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.endsWith('/match') && opts?.method === 'POST') {
+        return Promise.resolve({ ok: true, json: async () => mockState, text: async () => '' });
+      }
+      if (u.endsWith(`/match/${mockState.id}/join`)) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'player1' }), text: async () => '' });
+      }
+      if (u.endsWith(`/match/${mockState.id}/twist`)) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 't2' }), text: async () => '' });
+      }
+      return Promise.reject(new Error('Unknown endpoint'));
+    });
+  });
+
+  it('disables bind when twist requires motif-echo', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), { target: { value: 'Alice' } });
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    const bead1 = await screen.findByTestId('bead-b1');
+    const bead2 = await screen.findByTestId('bead-b2');
+    fireEvent.click(bead1);
+    fireEvent.click(bead2);
+    const bindButton = screen.getByRole('button', { name: 'Bind Selected' });
+    expect(bindButton).not.toBeDisabled();
+
+    fireEvent.click(screen.getByText('Draw Twist'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/twist`),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    const ws = MockWebSocket.instances[0];
+    const twistState = {
+      ...mockState,
+      twist: {
+        id: 't2',
+        name: 'Motif Echo',
+        description: 'Relations must be motif-echo',
+        effect: { requiredRelation: 'motif-echo' },
+      },
+    };
+    ws.onmessage?.({ data: JSON.stringify({ type: 'state:update', payload: twistState }) } as MessageEvent);
+
+    await waitFor(() => expect(bindButton).toBeDisabled());
+  });
+});
+


### PR DESCRIPTION
## Summary
- cover twist-required relation logic on server
- verify React UI disables disallowed actions when twist in play

## Testing
- `npm test` *(fails: judge produces deterministic scores and winner)*

------
https://chatgpt.com/codex/tasks/task_e_68c02043f944832ca6134dabffdf72ba