### PR TITLE
Add counterpoint move broadcast test

### DIFF
--- a/apps/server/test/counterpoint.test.ts
+++ b/apps/server/test/counterpoint.test.ts
@@ -1,0 +1,171 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import WebSocket from 'ws';
+import { startServer } from './server.helper.js';
+
+function waitForMessage(ws: WebSocket, type: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const handler = (data: WebSocket.RawData) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === type) {
+          ws.off('message', handler);
+          resolve(msg.payload);
+        }
+      } catch (err) {
+        reject(err);
+      }
+    };
+    ws.on('message', handler);
+    ws.on('close', () => reject(new Error('closed')));
+  });
+}
+
+test('counterpoint move broadcasts and rejects invalid label', async (t) => {
+  const port = 9998;
+  const server = await startServer(port);
+  t.after(() => server.kill());
+  const base = `http://127.0.0.1:${port}`;
+
+  // --- valid counterpoint setup ---
+  const match = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const matchId = match.id as string;
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+  const p1 = await join('Alice');
+  await join('Bob');
+
+  const cast = async (content: string) => {
+    const bead = {
+      id: `b_${Math.random().toString(36).slice(2,8)}`,
+      ownerId: p1.id,
+      modality: 'text',
+      content,
+      complexity: 1,
+      createdAt: Date.now()
+    };
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p1.id,
+      type: 'cast',
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    await fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+    return bead.id;
+  };
+  const b1 = await cast('one');
+  const b2 = await cast('two');
+
+  // draw twists until motif-echo requirement
+  await fetch(`${base}/match/${matchId}/twist`, { method: 'POST' });
+  await fetch(`${base}/match/${matchId}/twist`, { method: 'POST' });
+
+  // open websockets
+  const ws1 = new WebSocket(`ws://127.0.0.1:${port}/?matchId=${matchId}`);
+  const ws2 = new WebSocket(`ws://127.0.0.1:${port}/?matchId=${matchId}`);
+  const initial1 = waitForMessage(ws1, 'state:update');
+  const initial2 = waitForMessage(ws2, 'state:update');
+  await Promise.all([
+    new Promise(res => ws1.once('open', res)),
+    new Promise(res => ws2.once('open', res))
+  ]);
+  await Promise.all([initial1, initial2]);
+
+  const edgeId = `m_${Math.random().toString(36).slice(2,8)}`;
+  const move = {
+    id: edgeId,
+    playerId: p1.id,
+    type: 'counterpoint',
+    payload: { from: b1, to: b2, label: 'motif-echo', justification: 'First. Second.' },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+  const next1 = waitForMessage(ws1, 'state:update');
+  const next2 = waitForMessage(ws2, 'state:update');
+  const res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+  assert.equal(res.status, 200);
+  const [update1, update2] = await Promise.all([next1, next2]);
+  assert.equal(update1.edges[edgeId].label, 'motif-echo');
+  assert.equal(update2.edges[edgeId].label, 'motif-echo');
+
+  const state = await (await fetch(`${base}/match/${matchId}`)).json();
+  assert.equal(state.edges[edgeId].label, 'motif-echo');
+
+  ws1.close();
+  ws2.close();
+
+  // --- failing case: wrong relation label ---
+  const badMatch = await (await fetch(`${base}/match`, { method: 'POST' })).json();
+  const badId = badMatch.id as string;
+  const joinBad = (handle: string) =>
+    fetch(`${base}/match/${badId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+  const pBad = await joinBad('A');
+  await joinBad('B');
+
+  const castBad = async () => {
+    const bead = {
+      id: `b_${Math.random().toString(36).slice(2,8)}`,
+      ownerId: pBad.id,
+      modality: 'text',
+      content: 'x',
+      complexity: 1,
+      createdAt: Date.now()
+    };
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: pBad.id,
+      type: 'cast',
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    await fetch(`${base}/match/${badId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+    return bead.id;
+  };
+  const bb1 = await castBad();
+  const bb2 = await castBad();
+  await fetch(`${base}/match/${badId}/twist`, { method: 'POST' });
+  await fetch(`${base}/match/${badId}/twist`, { method: 'POST' });
+
+  const badMove = {
+    id: `m_${Math.random().toString(36).slice(2,8)}`,
+    playerId: pBad.id,
+    type: 'counterpoint',
+    payload: { from: bb1, to: bb2, label: 'analogy', justification: 'First. Second.' },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+  const badRes = await fetch(`${base}/match/${badId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(badMove)
+  });
+  assert.equal(badRes.status, 400);
+});
+


### PR DESCRIPTION
## Summary
- test counterpoint move broadcasts edge via state:update and persists to match
- ensure counterpoint with wrong relation label returns 400

## Testing
- `npm test --workspace apps/server` *(fails: cast move broadcasts new bead to all players; judge produces deterministic scores and winner)*

------
https://chatgpt.com/codex/tasks/task_e_68c02044f61c832cb09f527c1f79cfe0