### PR TITLE
feat: add cathedral creation move and composer

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "pretest": "npm --workspace @gbg/types run build && npm run build",
-    "test": "node --test --import tsx test/*.test.ts"
+    "test": "NODE_OPTIONS=--dns-result-order=ipv4first node --test --import tsx test/*.test.ts"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",

--- a/apps/server/test/cathedral.test.ts
+++ b/apps/server/test/cathedral.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { startServer, createMatchWithMoves } from './server.helper.js';
+
+// ensure cathedral route stores final node
+
+test('cathedral route stores final node', async (t) => {
+  const port = 9994;
+  const server = await startServer(port);
+  t.after(() => server.kill());
+  const base = `http://127.0.0.1:${port}`;
+
+  const { matchId, bead, p1 } = await createMatchWithMoves(base);
+
+  const res = await fetch(`${base}/match/${matchId}/cathedral`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId: p1.id, content: 'Final idea', references: [bead.id] })
+  });
+  assert.equal(res.ok, true);
+
+  const state = await (await fetch(`${base}/match/${matchId}`)).json();
+  assert.equal(state.cathedral.content, 'Final idea');
+  assert.deepEqual(state.cathedral.references, [bead.id]);
+});

--- a/apps/server/test/server.helper.ts
+++ b/apps/server/test/server.helper.ts
@@ -51,6 +51,6 @@ export async function createMatchWithMoves(base: string){
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(move)
   });
-  return { matchId, bead, move };
+  return { matchId, bead, move, p1 };
 }
 

--- a/packages/types/test/cathedral.test.ts
+++ b/packages/types/test/cathedral.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GameState, Move, Bead, validateMove, applyMove } from '../src/index.ts';
+
+test('cathedral move validates and applies', () => {
+  const bead: Bead = { id: 'b1', ownerId: 'p1', modality: 'text', content: 'a', complexity: 1, createdAt: 0 };
+  const state: GameState = {
+    id: 'g1',
+    round: 1,
+    phase: 'play',
+    players: [ { id: 'p1', handle: 'P1', resources: { insight: 0, restraint: 0, wildAvailable: true } } ],
+    seeds: [],
+    beads: { b1: bead },
+    edges: {},
+    moves: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  const move: Move = {
+    id: 'm1',
+    playerId: 'p1',
+    type: 'cathedral',
+    payload: { content: 'Final <b>idea</b>', references: ['b1'] },
+    timestamp: 1,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(move, state).ok, true);
+  applyMove(state, move);
+  assert.equal(state.cathedral?.content, 'Final <b>idea</b>');
+  assert.deepEqual(state.cathedral?.references, ['b1']);
+
+  const badMove: Move = {
+    id: 'm2',
+    playerId: 'p1',
+    type: 'cathedral',
+    payload: { content: '', references: ['missing'] },
+    timestamp: 2,
+    durationMs: 0,
+    valid: true,
+  };
+  assert.equal(validateMove(badMove, state).ok, false);
+});


### PR DESCRIPTION
## Summary
- support `cathedral` move type and store cathedral content in game state
- expose `/match/:id/cathedral` API to submit final node
- add web composer UI for cathedral text and references
- cover cathedral validation and route with tests

## Testing
- `npm test` *(fails: fetch failed in server tests)*
- `npm --workspace packages/types run test`


------
https://chatgpt.com/codex/tasks/task_e_68c020479784832caabd93c99cf17600