### PR TITLE
feat: limit path enumeration depth

### DIFF
--- a/apps/server/src/judge/index.ts
+++ b/apps/server/src/judge/index.ts
@@ -36,7 +36,7 @@ export function judge(state: GameState): JudgmentScroll {
   const graph: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
   for (const bead of Object.values(state.beads)) addBead(graph, bead);
   for (const edge of Object.values(state.edges)) addEdge(graph, edge);
-  const strongPaths = findStrongestPaths(graph, 3).map(p => ({
+  const strongPaths = findStrongestPaths(graph, 3, { maxDepth: 8, maxVisits: 1_000 }).map(p => ({
     nodes: p.nodes,
     why: `weight ${p.weight.toFixed(2)}`
   }));


### PR DESCRIPTION
## Summary
- add depth and visit limits to findStrongestPaths
- bound judge strong path search to avoid runaway recursion

## Testing
- `npm --workspace packages/types test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c03b269d90832c9a05ef855f0f7dd9