### PR TITLE
feat(types): add computeLift helper

### DIFF
--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -135,3 +135,29 @@ export function findStrongestPaths(state: GraphState, topN = 3): PathWeight[] {
   return results.slice(0, topN);
 }
 
+/**
+ * Compute a lift score for each bead based on the cumulative weights of all
+ * simple paths it participates in. Scores are normalized to the range [0,1].
+ */
+export function computeLift(state: GraphState): Record<string, number> {
+  const scores: Record<string, number> = {};
+
+  // initialize all bead scores to 0 so isolated beads are represented
+  for (const id of Object.keys(state.beads)) scores[id] = 0;
+
+  const paths = findStrongestPaths(state, Infinity);
+  for (const path of paths) {
+    for (const nodeId of path.nodes) {
+      scores[nodeId] = (scores[nodeId] ?? 0) + path.weight;
+    }
+  }
+
+  const max = Math.max(0, ...Object.values(scores));
+  if (max > 0) {
+    for (const id of Object.keys(scores)) {
+      scores[id] = scores[id] / max;
+    }
+  }
+  return scores;
+}
+

--- a/packages/types/test/graph.test.ts
+++ b/packages/types/test/graph.test.ts
@@ -8,6 +8,7 @@ import {
   neighbors,
   longestPathFrom,
   maxWeightedPathFrom,
+  computeLift,
 } from '../src/graph.ts';
 import type { Bead, Edge } from '../src/index.ts';
 
@@ -59,4 +60,23 @@ test('longest and weighted path search', () => {
   const weighted = maxWeightedPathFrom(state, 'a', weightFn);
   assert.deepEqual(weighted.path, ['a', 'b', 'c']);
   assert.equal(weighted.weight, 7);
+});
+
+test('computeLift aggregates path weights and normalizes', () => {
+  const state: GraphState = { beads: {}, edges: {}, outbound: {}, inbound: {} };
+  const beads: Bead[] = ['a', 'b', 'c'].map((id) => ({
+    id,
+    ownerId: 'p',
+    modality: 'text',
+    content: '',
+    complexity: 1,
+    createdAt: 0,
+  }));
+  beads.forEach((b) => addBead(state, b));
+
+  addEdge(state, { id: 'e1', from: 'a', to: 'b', label: 'analogy', justification: '' });
+  addEdge(state, { id: 'e2', from: 'b', to: 'c', label: 'analogy', justification: '' });
+
+  const lift = computeLift(state);
+  assert.deepEqual(lift, { a: 0.75, b: 1, c: 0.75 });
 });


### PR DESCRIPTION
## Summary
- add computeLift helper to score beads by cumulative path weight
- expose helper through types package and test lifting behaviour

## Testing
- `npm run test:types`
- `npm run typecheck:types`
- `npm run build:types`
- `npm test` *(fails: command sh -c node --test --import tsx test/*.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c048bf3730832c8e962c524e359d34