### PR TITLE
Fix replay graph rendering without websocket

### DIFF
--- a/apps/web/src/hooks/useMatchState.test.tsx
+++ b/apps/web/src/hooks/useMatchState.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import useMatchState from './useMatchState';
+import type { GameState } from '@gbg/types';
+
+const baseState: Omit<GameState, 'id'> = {
+  round: 1,
+  phase: 'play',
+  players: [],
+  currentPlayerId: undefined,
+  seeds: [],
+  beads: {},
+  edges: {},
+  moves: [],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+function Wrapper({ initial }: { initial: GameState }) {
+  const { state } = useMatchState(undefined, { autoConnect: false, initialState: initial });
+  return <div>{state?.id}</div>;
+}
+
+test('updates state when initialState changes', () => {
+  const stateA: GameState = { ...baseState, id: 'A' };
+  const stateB: GameState = { ...baseState, id: 'B' };
+  const { rerender } = render(<Wrapper initial={stateA} />);
+  expect(screen.getByText('A')).toBeInTheDocument();
+  rerender(<Wrapper initial={stateB} />);
+  expect(screen.getByText('B')).toBeInTheDocument();
+});

--- a/apps/web/src/hooks/useMatchState.ts
+++ b/apps/web/src/hooks/useMatchState.ts
@@ -19,6 +19,10 @@ export default function useMatchState(
 ) {
   const { autoConnect = true, initialState = null } = opts;
   const [state, setState] = useState<GameState | null>(initialState);
+  // Reset internal state whenever a new initial state is provided
+  useEffect(() => {
+    setState(initialState);
+  }, [initialState]);
   const wsRef = useRef<WebSocket | null>(null);
 
   const disconnect = useCallback(() => {


### PR DESCRIPTION
## Summary
- reset match state when initialState changes so replays refresh
- add test for useMatchState reacting to new initial state

## Testing
- `npm run typecheck`
- `npm test` *(fails: server tests fail 1 of 15)*
- `npm test --workspace=@gbg/web`


------
https://chatgpt.com/codex/tasks/task_e_68c04acad7cc832c89ce9f99139f8836