### PR TITLE
Fix ratings test port to avoid conflicts

### DIFF
--- a/apps/server/test/ratings.test.ts
+++ b/apps/server/test/ratings.test.ts
@@ -5,7 +5,7 @@ import { startServer } from './server.helper.js';
 // Ensure server ratings endpoint aggregates standings correctly
 
 // Using unique port to avoid collisions
-const PORT = 9998;
+const PORT = 9997;
 
 test('ratings endpoint aggregates standings', async (t) => {
   const server = await startServer(PORT);


### PR DESCRIPTION
## Summary
- use an unused port for ratings endpoint test

## Testing
- `npm test --workspace apps/server` (fails: judge produces deterministic scores and winner)
- `npm test --workspace apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68c04b232f3c832cb24494ae756d923d