### PR TITLE
Add counterpoint move broadcast test

### DIFF
--- a/apps/server/test/counterpoint.test.ts
+++ b/apps/server/test/counterpoint.test.ts
@@ -22,7 +22,8 @@ function waitForMessage(ws: WebSocket, type: string): Promise<any> {
 }
 
 test('counterpoint move broadcasts and rejects invalid label', async (t) => {
-  const port = 9998;
+  // Use a dedicated port to prevent collisions with other tests
+  const port = 10000;
   const server = await startServer(port);
   t.after(() => server.kill());
   const base = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
## Summary
- use a unique port for counterpoint test to avoid clashes with other server tests

## Testing
- `node --test --import tsx test/*.test.ts` *(fails: 7 failing, 11 passing)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b50c370832c8aafcb405184ea39