### PR TITLE
feat: add cathedral creation move and composer

### DIFF
--- a/apps/server/test/cathedral.test.ts
+++ b/apps/server/test/cathedral.test.ts
@@ -5,7 +5,7 @@ import { startServer, createMatchWithMoves } from './server.helper.js';
 // ensure cathedral route stores final node
 
 test('cathedral route stores final node', async (t) => {
-  const port = 9994;
+  const port = 9997;
   const server = await startServer(port);
   t.after(() => server.kill());
   const base = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
## Summary
- support `cathedral` move type and store cathedral content in game state
- expose `/match/:id/cathedral` API to submit final node
- add web composer UI for cathedral text and references
- cover cathedral validation and route with tests
- use a dedicated port in cathedral test to avoid metrics collision

## Testing
- `npm test` *(fails: judge produces deterministic scores and winner assertion)*
- `npm --workspace packages/types run test`


------
https://chatgpt.com/codex/tasks/task_e_68c04b7bf4bc832c85fcc255678eecdf