### PR TITLE
feat: add cathedral creation move and composer

### DIFF
--- a/apps/server/test/cathedral.test.ts
+++ b/apps/server/test/cathedral.test.ts
@@ -5,7 +5,7 @@ import { startServer, createMatchWithMoves } from './server.helper.js';
 // ensure cathedral route stores final node
 
 test('cathedral route stores final node', async (t) => {
-  const port = 9994;
+  const port = 9997;
   const server = await startServer(port);
   t.after(() => server.kill());
   const base = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
## Summary
- assign unique port to `cathedral` server test to avoid collision with metrics server

## Testing
- `npm --workspace apps/server run test` *(fails: judge produces deterministic scores and winner)*
- `npm --workspace packages/types run test`


------
https://chatgpt.com/codex/tasks/task_e_68c04b9795dc832cab9c88eaad9789ed