### PR TITLE
fix: align steps with truncated path on limits

### DIFF
--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -112,7 +112,9 @@ export function findStrongestPaths(
     steps: Array<{ from: string; to: string; weight: number }>
   ) => {
     if (visits >= maxVisits || path.length >= maxDepth) {
+      const lastStep = steps.pop();
       results.push({ nodes: [...path], weight, steps: [...steps] });
+      if (lastStep) steps.push(lastStep);
       return;
     }
     visits++;


### PR DESCRIPTION
## Summary
- remove dangling edge when path search exits early so steps and nodes stay in sync

## Testing
- `npm --workspace packages/types test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04ba86ca8832cbbe93189959336e3