### PR TITLE
fix: apply lift force on simulation rebuild

### DIFF
--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -162,7 +162,7 @@ export default function GraphView({
       )
       .alpha(1)
       .restart();
-  }, [lift, liftStrength, height]);
+  }, [state, lift, liftStrength, height]);
 
   return <svg ref={svgRef} width={width} height={height} />;
 }


### PR DESCRIPTION
## Summary
- include `state` in lift-force effect dependencies so lift is applied when the simulation is recreated

## Testing
- `npm --workspace apps/web run test`
- `npm --workspace apps/web run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04be71644832c9f13b770930c080b