### PR TITLE
docs(types): clarify traversal options for findStrongestPaths

### DIFF
--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -98,6 +98,7 @@ export function maxWeightedPathFrom(
 export function findStrongestPaths(
   state: GraphState,
   topN = 3,
+  // traversal limits
   opts: { maxDepth?: number; maxVisits?: number } = {}
 ): PathWeight[] {
   const { maxDepth = 10, maxVisits = 1_000 } = opts;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -266,4 +266,5 @@ export function replayMoves(initial: GameState, moves: Move[]): GameState {
   return state;
 }
 
+// graph utilities
 export * from './graph.js';


### PR DESCRIPTION
## Summary
- document traversal limits for `findStrongestPaths`
- note re-export of graph utilities from types entrypoint

## Testing
- `npm --workspace packages/types run build`
- `npm --workspace packages/types test`

------
https://chatgpt.com/codex/tasks/task_e_68c05124e650832c91df8b36d370d4aa