### PR TITLE
feat(types): extend move type union

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,17 +18,20 @@ export interface Bead {
 export interface Edge {
   id: string; from: string; to: string; label: RelationLabel; justification: string;
 }
-export type MoveType =
-  | "cast"
-  | "bind"
-  | "transmute"
-  | "lift"
-  | "refute"
-  | "canonize"
-  | "prune"
-  | "mirror"
-  | "counterpoint"
-  | "joker";
+export const MOVE_TYPES = [
+  "cast",
+  "bind",
+  "transmute",
+  "lift",
+  "refute",
+  "canonize",
+  "prune",
+  "mirror",
+  "counterpoint",
+  "joker",
+] as const;
+
+export type MoveType = (typeof MOVE_TYPES)[number];
 export interface Move {
   id: string; playerId: string; type: MoveType; payload: any;
   timestamp: number; durationMs: number; valid: boolean; notes?: string;


### PR DESCRIPTION
## Summary
- derive `MoveType` from a central `MOVE_TYPES` list covering bind, mirror, counterpoint, and other moves
- rebuild the `@gbg/types` package

## Testing
- `npm run typecheck:types`
- `npm run test:types`
- `npm run build:types`


------
https://chatgpt.com/codex/tasks/task_e_68c05125ade0832c8e06335b51565489