### PR TITLE
feat(server-tests): add dynamic port allocation

### DIFF
--- a/apps/server/test/concord.test.ts
+++ b/apps/server/test/concord.test.ts
@@ -7,8 +7,7 @@ function randomId(prefix: string) {
 }
 
 test('concord builds cathedral from highest path', async (t) => {
-  const port = 9992;
-  const server = await startServer(port);
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 

--- a/apps/server/test/counterpoint.test.ts
+++ b/apps/server/test/counterpoint.test.ts
@@ -22,9 +22,7 @@ function waitForMessage(ws: WebSocket, type: string): Promise<any> {
 }
 
 test('counterpoint move broadcasts and rejects invalid label', async (t) => {
-  // Use a dedicated port to prevent collisions with other tests
-  const port = 10000;
-  const server = await startServer(port);
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://127.0.0.1:${port}`;
 

--- a/apps/server/test/log.test.ts
+++ b/apps/server/test/log.test.ts
@@ -5,8 +5,7 @@ import { startServer, createMatchWithMoves } from './server.helper.js';
 // Ensure we can download match log with moves and beads
 
 test('match log download contains moves and beads', async (t) => {
-  const port = 9995;
-  const server = await startServer(port);
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 

--- a/apps/server/test/match.test.ts
+++ b/apps/server/test/match.test.ts
@@ -1,24 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { startServer } from './server.helper.js';
 
 test('players can join a match and be listed in state', async (t) => {
-  const cwd = path.join(__dirname, '..');
-  const server = spawn('node', ['dist/index.js'], {
-    cwd,
-    env: { ...process.env, PORT: '9998' },
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
-  await new Promise(res => setTimeout(res, 1000));
+  const { server, port } = await startServer();
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9998';
+  const base = `http://127.0.0.1:${port}`;
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/metrics.test.ts
+++ b/apps/server/test/metrics.test.ts
@@ -1,24 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { startServer } from './server.helper.js';
 
 test('metrics endpoint reports move counts and latency', async (t) => {
-  const cwd = path.join(__dirname, '..');
-  const server = spawn('node', ['dist/index.js'], {
-    cwd,
-    env: { ...process.env, PORT: '9994' },
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
-  await new Promise(res => setTimeout(res, 1000));
+  const { server, port } = await startServer();
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9994';
+  const base = `http://127.0.0.1:${port}`;
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -1,25 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-function startServer(port: number){
-  const cwd = path.join(__dirname, '..');
-  const server = spawn('node', ['dist/index.js'], {
-    cwd,
-    env: { ...process.env, PORT: String(port) },
-    stdio: ['ignore','pipe','pipe']
-  });
-  return server;
-}
+import { startServer } from './server.helper.js';
 
 test('cast rejects when insight and wild exhausted', async (t) => {
-  const port = 9993;
-  const server = startServer(port);
-  await new Promise(r => setTimeout(r, 1000));
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 
@@ -81,9 +65,7 @@ test('cast rejects when insight and wild exhausted', async (t) => {
 });
 
 test('bind uses restraint then wild then rejects', async (t) => {
-  const port = 9996;
-  const server = startServer(port);
-  await new Promise(r => setTimeout(r, 1000));
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 

--- a/apps/server/test/ratings.test.ts
+++ b/apps/server/test/ratings.test.ts
@@ -4,15 +4,12 @@ import { startServer } from './server.helper.js';
 
 // Ensure server ratings endpoint aggregates standings correctly
 
-// Using unique port to avoid collisions
-const PORT = 9997;
-
 test('ratings endpoint aggregates standings', async (t) => {
-  const server = await startServer(PORT);
+  const { server, port } = await startServer();
   t.after(() => {
     server.kill();
   });
-  const base = `http://127.0.0.1:${PORT}`;
+  const base = `http://127.0.0.1:${port}`;
 
   const post = (handle: string, result: 'win' | 'loss') =>
     fetch(`${base}/ratings`, {

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -1,24 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { startServer } from './server.helper.js';
 
 test('turn switches to next player after move', async (t) => {
-  const cwd = path.join(__dirname, '..');
-  const server = spawn('node', ['dist/index.js'], {
-    cwd,
-    env: { ...process.env, PORT: '9992' },
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
-  await new Promise(res => setTimeout(res, 1000));
+  const { server, port } = await startServer();
   t.after(() => {
     server.kill();
   });
 
-  const base = 'http://127.0.0.1:9992';
+  const base = `http://127.0.0.1:${port}`;
 
   const matchRes = await fetch(`${base}/match`, { method: 'POST' });
   const match = await matchRes.json();

--- a/apps/server/test/twist.test.ts
+++ b/apps/server/test/twist.test.ts
@@ -1,25 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-function startServer(port: number){
-  const cwd = path.join(__dirname, '..');
-  const server = spawn('node', ['dist/index.js'], {
-    cwd,
-    env: { ...process.env, PORT: String(port) },
-    stdio: ['ignore','pipe','pipe']
-  });
-  return server;
-}
+import { startServer } from './server.helper.js';
 
 test('twist rejects bind with wrong relation', async (t) => {
-  const port = 9997;
-  const server = startServer(port);
-  await new Promise(r => setTimeout(r, 1000));
+  const { server, port } = await startServer();
   t.after(() => server.kill());
   const base = `http://localhost:${port}`;
 


### PR DESCRIPTION
## Summary
- add `getFreePort` helper and update `startServer` to choose an available port
- refactor server test suite to use dynamic ports via shared helper

## Testing
- `npm --workspace apps/server test`


------
https://chatgpt.com/codex/tasks/task_e_68c0587ea704832c8c81afd253cbebc5