### PR TITLE
fix: stabilize React tests with async waits

### DIFF
--- a/apps/web/src/GraphView.test.tsx
+++ b/apps/web/src/GraphView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import GraphView from './GraphView';
 import type { GameState } from '@gbg/types';
 
@@ -22,28 +22,32 @@ const state: GameState = {
   updatedAt: 0,
 };
 
-test('renders nodes/edges and highlights strong paths', () => {
+test('renders nodes/edges and highlights strong paths', async () => {
   const strongPaths = [{ nodes: ['a', 'b'] }];
   const { container } = render(
     <GraphView initialState={state} strongPaths={strongPaths} selectedPathIndex={0} width={200} height={200} />
   );
-  const nodes = container.querySelectorAll('circle');
-  const edges = container.querySelectorAll('line');
-  expect(nodes.length).toBe(2);
-  expect(edges.length).toBe(1);
-  nodes.forEach((n) => expect(n.getAttribute('fill')).toBe('#ef4444'));
-  const edge = edges[0];
-  expect(edge.getAttribute('stroke')).toBe('#ef4444');
-  expect(edge.getAttribute('stroke-width')).toBe('3');
+  await waitFor(() => {
+    const nodes = container.querySelectorAll('circle');
+    const edges = container.querySelectorAll('line');
+    expect(nodes.length).toBe(2);
+    expect(edges.length).toBe(1);
+    nodes.forEach((n) => expect(n.getAttribute('fill')).toBe('#ef4444'));
+    const edge = edges[0];
+    expect(edge.getAttribute('stroke')).toBe('#ef4444');
+    expect(edge.getAttribute('stroke-width')).toBe('3');
+  });
 });
 
-test('renders cathedral node when present', () => {
+test('renders cathedral node when present', async () => {
   const catState: GameState = {
     ...state,
     cathedral: { id: 'cat', content: 'summary', references: ['a', 'b'] },
   };
   const { container } = render(<GraphView initialState={catState} width={200} height={200} />);
-  const cathedralNode = container.querySelector('#cat');
-  expect(cathedralNode).not.toBeNull();
-  expect(cathedralNode?.getAttribute('fill')).toBe('#fbbf24');
+  await waitFor(() => {
+    const cathedralNode = container.querySelector('#cat');
+    expect(cathedralNode).not.toBeNull();
+    expect(cathedralNode?.getAttribute('fill')).toBe('#fbbf24');
+  });
 });

--- a/apps/web/src/hooks/useMatchState.test.tsx
+++ b/apps/web/src/hooks/useMatchState.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import useMatchState from './useMatchState';
 import type { GameState } from '@gbg/types';
 
@@ -21,11 +21,11 @@ function Wrapper({ initial }: { initial: GameState }) {
   return <div>{state?.id}</div>;
 }
 
-test('updates state when initialState changes', () => {
+test('updates state when initialState changes', async () => {
   const stateA: GameState = { ...baseState, id: 'A' };
   const stateB: GameState = { ...baseState, id: 'B' };
   const { rerender } = render(<Wrapper initial={stateA} />);
   expect(screen.getByText('A')).toBeInTheDocument();
   rerender(<Wrapper initial={stateB} />);
-  expect(screen.getByText('B')).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByText('B')).toBeInTheDocument());
 });


### PR DESCRIPTION
## Summary
- make GraphView tests wait for D3 rendering before asserting
- wait for state updates in useMatchState hook test

## Testing
- `npm --workspace apps/web test`
- `npm test` *(fails: bind uses restraint then wild then rejects, fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c6013b28832c844f73182465058a