### PR TITLE
Use data-join pattern for GraphView nodes

### DIFF
--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -91,9 +91,8 @@ export default function GraphView({
       .attr("stroke", "#fff")
       .attr("stroke-width", 1.5)
       .selectAll<SVGCircleElement, Node>("circle")
-      .data(nodes)
-      .enter()
-      .append("circle")
+      .data(nodes, (d) => d.id)
+      .join("circle")
       .attr("id", (d) => d.id)
       .attr("r", 10)
       .attr("fill", (d) =>


### PR DESCRIPTION
## Summary
- replace `enter().append("circle")` with `data(nodes, d => d.id).join("circle")`
- ensure id attribute applied before radius and fill
- confirm cathedral nodes are present in data

## Testing
- `npm --workspace apps/web test -- GraphView.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0cf88c9f8832cb7916159b19a9c11