### PR TITLE
Initialize match state from effect

### DIFF
--- a/apps/web/src/hooks/useMatchState.ts
+++ b/apps/web/src/hooks/useMatchState.ts
@@ -18,7 +18,7 @@ export default function useMatchState(
   opts: { autoConnect?: boolean; initialState?: GameState | null } = {}
 ) {
   const { autoConnect = true, initialState = null } = opts;
-  const [state, setState] = useState<GameState | null>(initialState);
+  const [state, setState] = useState<GameState | null>(null);
   // Reset internal state whenever a new initial state is provided
   useEffect(() => {
     setState(initialState);


### PR DESCRIPTION
## Summary
- initialize match hook state from `null` and sync it with `initialState`

## Testing
- `npm --workspace apps/web test apps/web/src/hooks/useMatchState.test.tsx`
- `npm --workspace apps/web test apps/web/src/GraphView.test.tsx`
- `npm --workspace apps/web test apps/web/src/App.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0cf89916c832cb4093d16f16ef3f3