### PR TITLE
Enforce turn order and stabilize server tests

### DIFF
--- a/apps/server/test/concord.test.ts
+++ b/apps/server/test/concord.test.ts
@@ -22,7 +22,6 @@ test('concord builds cathedral from highest path', async (t) => {
     }).then((r) => r.json());
 
   const p1 = await join('Alice');
-  await join('Bob');
 
   const castBead = async (id: string, title: string) => {
     const bead = {

--- a/apps/server/test/counterpoint.test.ts
+++ b/apps/server/test/counterpoint.test.ts
@@ -36,12 +36,12 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
       body: JSON.stringify({ handle })
     }).then(r => r.json());
   const p1 = await join('Alice');
-  await join('Bob');
+  const p2 = await join('Bob');
 
-  const cast = async (content: string) => {
+  const cast = async (player: any, content: string) => {
     const bead = {
       id: `b_${Math.random().toString(36).slice(2,8)}`,
-      ownerId: p1.id,
+      ownerId: player.id,
       modality: 'text',
       content,
       complexity: 1,
@@ -49,7 +49,7 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
     };
     const move = {
       id: `m_${Math.random().toString(36).slice(2,8)}`,
-      playerId: p1.id,
+      playerId: player.id,
       type: 'cast',
       payload: { bead },
       timestamp: Date.now(),
@@ -63,8 +63,8 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
     });
     return bead.id;
   };
-  const b1 = await cast('one');
-  const b2 = await cast('two');
+  const b1 = await cast(p1, 'one');
+  const b2 = await cast(p2, 'two');
 
   // draw twists until motif-echo requirement
   await fetch(`${base}/match/${matchId}/twist`, { method: 'POST' });
@@ -119,12 +119,12 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
       body: JSON.stringify({ handle })
     }).then(r => r.json());
   const pBad = await joinBad('A');
-  await joinBad('B');
+  const pBad2 = await joinBad('B');
 
-  const castBad = async () => {
+  const castBad = async (player: any) => {
     const bead = {
       id: `b_${Math.random().toString(36).slice(2,8)}`,
-      ownerId: pBad.id,
+      ownerId: player.id,
       modality: 'text',
       content: 'x',
       complexity: 1,
@@ -132,7 +132,7 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
     };
     const move = {
       id: `m_${Math.random().toString(36).slice(2,8)}`,
-      playerId: pBad.id,
+      playerId: player.id,
       type: 'cast',
       payload: { bead },
       timestamp: Date.now(),
@@ -146,8 +146,8 @@ test('counterpoint move broadcasts and rejects invalid label', async (t) => {
     });
     return bead.id;
   };
-  const bb1 = await castBad();
-  const bb2 = await castBad();
+  const bb1 = await castBad(pBad);
+  const bb2 = await castBad(pBad2);
   await fetch(`${base}/match/${badId}/twist`, { method: 'POST' });
   await fetch(`${base}/match/${badId}/twist`, { method: 'POST' });
 

--- a/apps/server/test/match.test.ts
+++ b/apps/server/test/match.test.ts
@@ -82,9 +82,9 @@ test('match handles all move types and returns AI judgment', async (t) => {
 
   await postMove({ id: `m_${Math.random().toString(36).slice(2,8)}`, playerId: p2.id, type: 'refute', payload: {}, timestamp: Date.now(), durationMs: 0, valid: true });
 
-  await postMove({ id: `m_${Math.random().toString(36).slice(2,8)}`, playerId: p2.id, type: 'prune', payload: {}, timestamp: Date.now(), durationMs: 0, valid: true });
+  await postMove({ id: `m_${Math.random().toString(36).slice(2,8)}`, playerId: p1.id, type: 'prune', payload: {}, timestamp: Date.now(), durationMs: 0, valid: true });
 
-  await postMove({ id: `m_${Math.random().toString(36).slice(2,8)}`, playerId: p1.id, type: 'joker', payload: {}, timestamp: Date.now(), durationMs: 0, valid: true });
+  await postMove({ id: `m_${Math.random().toString(36).slice(2,8)}`, playerId: p2.id, type: 'joker', payload: {}, timestamp: Date.now(), durationMs: 0, valid: true });
 
   const state = await (await fetch(`${base}/match/${matchId}`)).json();
   assert.equal(Object.keys(state.beads).length, 2);

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -18,7 +18,6 @@ test('cast rejects when insight and wild exhausted', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
-  await join('B');
 
   const cast = async () => {
     const bead = {
@@ -80,7 +79,6 @@ test('bind uses restraint then wild then rejects', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
-  await join('B');
 
   // cast two beads to bind
   const castBead = async (id:string) => {

--- a/apps/server/test/server.helper.ts
+++ b/apps/server/test/server.helper.ts
@@ -29,7 +29,18 @@ export async function startServer(port?: number): Promise<{ server: ChildProcess
     env: { ...process.env, PORT: String(actualPort) },
     stdio: ['ignore', 'pipe', 'pipe']
   });
-  await new Promise(res => setTimeout(res, 1000));
+  const start = Date.now();
+  await new Promise((resolve, reject) => {
+    const check = () => {
+      fetch(`http://127.0.0.1:${actualPort}/match`)
+        .then(() => resolve(undefined))
+        .catch(err => {
+          if (Date.now() - start > 5000) return reject(err);
+          setTimeout(check, 100);
+        });
+    };
+    check();
+  });
   return { server, port: actualPort };
 }
 

--- a/apps/server/test/turn.test.ts
+++ b/apps/server/test/turn.test.ts
@@ -57,3 +57,53 @@ test('turn switches to next player after move', async (t) => {
   state = await stateRes.json();
   assert.equal(state.currentPlayerId, p2.id);
 });
+
+test('rejects move when not your turn', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => {
+    server.kill();
+  });
+
+  const base = `http://127.0.0.1:${port}`;
+  const matchRes = await fetch(`${base}/match`, { method: 'POST' });
+  const match = await matchRes.json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+  const p2 = await join('Bob');
+
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2, 8)}`,
+    ownerId: p2.id,
+    modality: 'text',
+    title: 'Idea',
+    content: 'simple',
+    complexity: 1,
+    createdAt: Date.now(),
+    seedId: match.seeds[0]?.id
+  };
+  const move = {
+    id: `m_${Math.random().toString(36).slice(2, 8)}`,
+    playerId: p2.id,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 1000,
+    valid: true
+  };
+  const res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(move)
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Not your turn');
+});

--- a/apps/server/test/twist.test.ts
+++ b/apps/server/test/twist.test.ts
@@ -18,7 +18,6 @@ test('twist rejects bind with wrong relation', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
-  await join('B');
 
   const castBead = async (id:string) => {
     const bead = { id, ownerId: p1.id, modality: 'text', content: 'x', complexity:1, createdAt: Date.now() };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -140,6 +140,8 @@ export function validateMove(move: Move, state: GameState): ValidationResult {
   if (!move || !state) return { ok: false, error: "Missing move or state" };
   const player = state.players.find((p) => p.id === move.playerId);
   if (!player) return { ok: false, error: "Unknown player" };
+  if (state.currentPlayerId && state.currentPlayerId !== player.id)
+    return { ok: false, error: "Not your turn" };
 
   const cost = MOVE_COSTS[move.type] ?? {};
   const insightShort = Math.max(0, (cost.insight ?? 0) - player.resources.insight);


### PR DESCRIPTION
## Summary
- reject moves from non-current players to enforce turn order
- add server test for out-of-turn move rejection and update existing tests to follow turn sequence
- wait for test server to start before running requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d389b464832ca9ab376a223f97af