### PR TITLE
feat(server): generate seeds with llm

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import registerMoveRoute from "./routes/move.js";
 import registerConcordRoute from "./routes/concord.js";
 import judge from "./judge/index.js";
 import judgeWithLLM from "./judge/llm.js";
+import generateSeeds from "./seeds.js";
 import { Ollama } from "ollama";
 
 const fastify = Fastify({ logger: false });
@@ -28,14 +29,6 @@ const ratings = new Map<string, { wins: number; losses: number }>();
 
 // --- Utility
 function now(){ return Date.now(); }
-function sampleSeeds(): GameState["seeds"]{
-  const seeds = [
-    {id:"s1", text:"Kepler's 3rd law", domain:"astronomy"},
-    {id:"s2", text:"West African kente patterns", domain:"textiles"},
-    {id:"s3", text:"Amnesty", domain:"civics"}
-  ];
-  return seeds;
-}
 
 function sampleTwists(): ConstraintCard[]{
   return [
@@ -98,8 +91,9 @@ function logMetrics(matchId: string, move: Move, state: GameState){
 // --- REST Endpoints
 fastify.post("/match", async (req, reply) => {
   const id = randomUUID().slice(0,8);
+  const seeds = await generateSeeds();
   const state: GameState = {
-    id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds: sampleSeeds(),
+    id, round: 1, phase:"SeedDraw", players: [], currentPlayerId: undefined, seeds,
     beads: {}, edges: {}, moves: [], twistDeck: sampleTwists(), createdAt: now(), updatedAt: now()
   };
   matches.set(id, state);

--- a/apps/server/src/seeds.ts
+++ b/apps/server/src/seeds.ts
@@ -1,0 +1,48 @@
+import { GameState, sanitizeMarkdown } from '@gbg/types';
+import { Ollama } from 'ollama';
+
+interface LLMClient {
+  generate(model: string, prompt: string): AsyncIterable<string>;
+}
+
+/** Return a fixed set of sample seeds used when no LLM is available. */
+export function sampleSeeds(): GameState['seeds'] {
+  return [
+    { id: 's1', text: "Kepler's 3rd law", domain: 'astronomy' },
+    { id: 's2', text: 'West African kente patterns', domain: 'textiles' },
+    { id: 's3', text: 'Amnesty', domain: 'civics' }
+  ];
+}
+
+/**
+ * Generate three seeds using a local LLM. Falls back to {@link sampleSeeds} on error
+ * or when no model is configured via the `LLM_MODEL` environment variable.
+ */
+export async function generateSeeds(
+  client: LLMClient = new Ollama()
+): Promise<GameState['seeds']> {
+  const model = process.env.LLM_MODEL;
+  if (!model) return sampleSeeds();
+  try {
+    const prompt =
+      'Provide 3 concise game seeds from disjoint knowledge domains as a JSON array of {"text","domain"}.';
+    let output = '';
+    for await (const part of client.generate(model, prompt)) {
+      output += part;
+    }
+    const parsed = JSON.parse(output);
+    if (Array.isArray(parsed)) {
+      const seeds = parsed.slice(0, 3).map((s: any, i: number) => ({
+        id: `s${i + 1}`,
+        text: sanitizeMarkdown(s.text ?? ''),
+        domain: sanitizeMarkdown(s.domain ?? '')
+      })).filter(s => s.text && s.domain);
+      if (seeds.length === 3) return seeds;
+    }
+  } catch (err) {
+    console.warn('LLM seed generation failed', err);
+  }
+  return sampleSeeds();
+}
+
+export default generateSeeds;

--- a/apps/server/test/seeds-llm.test.ts
+++ b/apps/server/test/seeds-llm.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateSeeds, sampleSeeds } from '../src/seeds.ts';
+
+test('generateSeeds returns sanitized LLM output', async (t) => {
+  const prev = process.env.LLM_MODEL;
+  process.env.LLM_MODEL = 'test';
+  t.after(() => {
+    if (prev === undefined) delete process.env.LLM_MODEL; else process.env.LLM_MODEL = prev;
+  });
+  const client = {
+    generate() {
+      return (async function* () {
+        yield JSON.stringify([
+          { text: '<script>alert(1)</script>Physics', domain: '<script>alert(1)</script>science' },
+          { text: 'Jazz', domain: 'music' },
+          { text: 'Daoism', domain: 'philosophy' }
+        ]);
+      })();
+    }
+  };
+  const seeds = await generateSeeds(client);
+  assert.equal(seeds.length, 3);
+  assert.equal(seeds[0].text, 'Physics');
+  assert.equal(seeds[0].domain, 'science');
+});
+
+test('generateSeeds falls back to sample seeds on error', async (t) => {
+  const prev = process.env.LLM_MODEL;
+  process.env.LLM_MODEL = 'test';
+  t.after(() => {
+    if (prev === undefined) delete process.env.LLM_MODEL; else process.env.LLM_MODEL = prev;
+  });
+  const client = {
+    generate() {
+      return (async function* () {
+        throw new Error('fail');
+      })();
+    }
+  };
+  const seeds = await generateSeeds(client);
+  assert.deepEqual(seeds, sampleSeeds());
+});


### PR DESCRIPTION
## Summary
- generate match seeds with an LLM when available
- create dedicated seed generation module and tests
- use LLM seeds during match creation

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0d9d35c7c832cbc505e11f3854cee