### PR TITLE
feat(web): add advanced move controls

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -54,6 +54,13 @@ describe('App', () => {
           text: async () => '',
         });
       }
+      if (u.endsWith(`/match/${mockState.id}/concord`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ cathedral: { id: 'cat', content: 'C', references: ['b1'] } }),
+          text: async () => '',
+        });
+      }
       return Promise.reject(new Error('Unknown endpoint'));
     });
   });
@@ -139,6 +146,56 @@ describe('App', () => {
     expect(bead2).not.toHaveAttribute('aria-selected', 'true');
   });
 
+  it('mirrors a selected bead and resets selection', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Idea 1')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Modality'), {
+      target: { value: 'image' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Share an idea...'), {
+      target: { value: 'Mirror bead' },
+    });
+
+    const bead1 = await screen.findByTestId('bead-b1');
+    fireEvent.click(bead1);
+
+    const mirrorButton = screen.getByRole('button', { name: 'Mirror Selected' });
+    fireEvent.click(mirrorButton);
+
+    await waitFor(() => {
+      const moveCall = (global.fetch as jest.Mock).mock.calls.find(c =>
+        (c[0] as string).includes('/move')
+      );
+      expect(moveCall).toBeTruthy();
+      const body = JSON.parse(moveCall![1].body as string);
+      expect(body.type).toBe('mirror');
+      expect(body.payload.targetId).toBe('b1');
+      expect(body.payload.bead.modality).toBe('image');
+    });
+
+    await waitFor(() => expect(mirrorButton).toBeDisabled());
+    expect(bead1).not.toHaveAttribute('aria-selected', 'true');
+  });
+
   it('populates textarea with AI suggestion', async () => {
     render(<App />);
 
@@ -171,5 +228,40 @@ describe('App', () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText('Share an idea...')).toHaveValue('AI idea')
     );
+  });
+
+  it('requests concord and updates graph', async () => {
+    const { container } = render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    const concordButton = screen.getByRole('button', { name: 'Concord' });
+    await waitFor(() => expect(concordButton).not.toBeDisabled());
+    fireEvent.click(concordButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/concord`),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      const cathedralNode = container.querySelector('#cat');
+      expect(cathedralNode).not.toBeNull();
+    });
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,8 +35,19 @@ export default function App() {
   const twistAllows = (type: Move["type"]): boolean => {
     const effect = state?.twist?.effect;
     if (!effect) return true;
-    if ((type === "cast" || type === "mirror") && effect.modalityLock && !effect.modalityLock.includes(beadModality)) return false;
-    if ((type === "bind" || type === "counterpoint" || type === "canonize" || type === "refute") && effect.requiredRelation) {
+    if (
+      (type === "cast" || type === "mirror") &&
+      effect.modalityLock &&
+      !effect.modalityLock.includes(beadModality)
+    )
+      return false;
+    if (
+      (type === "bind" ||
+        type === "counterpoint" ||
+        type === "canonize" ||
+        type === "refute") &&
+      effect.requiredRelation
+    ) {
       const labelMap: Record<string, string> = {
         bind: "analogy",
         counterpoint: "motif-echo",
@@ -46,7 +57,13 @@ export default function App() {
       const label = labelMap[type];
       if (label && label !== effect.requiredRelation) return false;
     }
-    if ((type === "bind" || type === "counterpoint" || type === "canonize" || type === "refute") && effect.justificationLimit) {
+    if (
+      (type === "bind" ||
+        type === "counterpoint" ||
+        type === "canonize" ||
+        type === "refute") &&
+      effect.justificationLimit
+    ) {
       const justificationMap: Record<string, string> = {
         bind: "Two features align; one disanalogy is noted.",
         counterpoint: "Inverted motif. Counter view.",
@@ -252,7 +269,6 @@ export default function App() {
       console.error("Failed to lift", err);
     }
   };
-
   const canonizeMove = async () => {
     if (!playerId || !state || selected.length !== 1 || !twistAllows("canonize")) return;
     const targetId = selected[0];
@@ -275,7 +291,6 @@ export default function App() {
       console.error("Failed to canonize", err);
     }
   };
-
   const refuteMove = async () => {
     if (!playerId || !state || selected.length !== 1 || !twistAllows("refute")) return;
     const targetId = selected[0];
@@ -298,7 +313,6 @@ export default function App() {
       console.error("Failed to refute", err);
     }
   };
-
   const pruneMove = async () => {
     if (!playerId || !state || selected.length !== 1 || !twistAllows("prune")) return;
     const targetId = selected[0];
@@ -321,7 +335,6 @@ export default function App() {
       console.error("Failed to prune", err);
     }
   };
-
   const jokerMove = async () => {
     if (!playerId || !state || !twistAllows("joker")) return;
     const move: Move = {
@@ -342,7 +355,6 @@ export default function App() {
       console.error("Failed to play joker", err);
     }
   };
-
   const drawTwist = async () => {
     if (!state) return;
     try {
@@ -476,69 +488,76 @@ export default function App() {
           >
             Suggest with AI
           </button>
-          <button
-            onClick={castBead}
-            disabled={!beadText.trim() || beadModality !== 'text' || !isMyTurn || !twistAllows("cast")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cast Bead
-          </button>
-          <button
-            onClick={bindSelected}
-            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("bind")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Bind Selected
-          </button>
-          <button
-            onClick={counterpointSelected}
-            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("counterpoint")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Counterpoint Selected
-          </button>
-          <button
-            onClick={mirrorSelected}
-            disabled={!isMyTurn || selected.length !== 1 || !beadText.trim() || !twistAllows("mirror")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Mirror Selected
-          </button>
-          <button
-            onClick={liftMove}
-            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("lift")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Lift
-          </button>
-          <button
-            onClick={canonizeMove}
-            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("canonize")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Canonize
-          </button>
-          <button
-            onClick={refuteMove}
-            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("refute")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Refute
-          </button>
-          <button
-            onClick={pruneMove}
-            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("prune")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Prune
-          </button>
-          <button
-            onClick={jokerMove}
-            disabled={!isMyTurn || !twistAllows("joker")}
-            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Joker
-          </button>
+          {[{
+            label: "Cast Bead",
+            onClick: castBead,
+            disabled:
+              !beadText.trim() ||
+              beadModality !== "text" ||
+              !isMyTurn ||
+              !twistAllows("cast"),
+          },
+          {
+            label: "Bind Selected",
+            onClick: bindSelected,
+            disabled:
+              !isMyTurn || selected.length !== 2 || !twistAllows("bind"),
+          },
+          {
+            label: "Counterpoint Selected",
+            onClick: counterpointSelected,
+            disabled:
+              !isMyTurn ||
+              selected.length !== 2 ||
+              !twistAllows("counterpoint"),
+          },
+          {
+            label: "Mirror Selected",
+            onClick: mirrorSelected,
+            disabled:
+              !isMyTurn ||
+              selected.length !== 1 ||
+              !beadText.trim() ||
+              !twistAllows("mirror"),
+          },
+          {
+            label: "Lift",
+            onClick: liftMove,
+            disabled:
+              !isMyTurn || selected.length !== 1 || !twistAllows("lift"),
+          },
+          {
+            label: "Canonize",
+            onClick: canonizeMove,
+            disabled:
+              !isMyTurn || selected.length !== 1 || !twistAllows("canonize"),
+          },
+          {
+            label: "Refute",
+            onClick: refuteMove,
+            disabled:
+              !isMyTurn || selected.length !== 1 || !twistAllows("refute"),
+          },
+          {
+            label: "Prune",
+            onClick: pruneMove,
+            disabled:
+              !isMyTurn || selected.length !== 1 || !twistAllows("prune"),
+          },
+          {
+            label: "Joker",
+            onClick: jokerMove,
+            disabled: !isMyTurn || !twistAllows("joker"),
+          }].map(({ label, onClick, disabled }) => (
+            <button
+              key={label}
+              onClick={onClick}
+              disabled={disabled}
+              className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {label}
+            </button>
+          ))}
           <button onClick={requestJudgment} disabled={!isMyTurn} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed">Request Judgment</button>
           <button onClick={requestConcord} disabled={!isMyTurn} className="w-full px-3 py-2 bg-amber-600 rounded hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed">Concord</button>
           <button onClick={exportLog} className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Export Log</button>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,12 +35,24 @@ export default function App() {
     const effect = state?.twist?.effect;
     if (!effect) return true;
     if ((type === "cast" || type === "mirror" || type === "counterpoint") && effect.modalityLock && !effect.modalityLock.includes("text")) return false;
-    if ((type === "bind" || type === "counterpoint") && effect.requiredRelation) {
-      const label = type === "bind" ? "analogy" : "motif-echo";
-      if (label !== effect.requiredRelation) return false;
+    if ((type === "bind" || type === "counterpoint" || type === "canonize" || type === "refute") && effect.requiredRelation) {
+      const labelMap: Record<string, string> = {
+        bind: "analogy",
+        counterpoint: "motif-echo",
+        canonize: "proof",
+        refute: "refutation",
+      };
+      const label = labelMap[type];
+      if (label && label !== effect.requiredRelation) return false;
     }
-    if ((type === "bind" || type === "counterpoint") && effect.justificationLimit) {
-      const justification = type === "bind" ? "Two features align; one disanalogy is noted." : "Inverted motif. Counter view.";
+    if ((type === "bind" || type === "counterpoint" || type === "canonize" || type === "refute") && effect.justificationLimit) {
+      const justificationMap: Record<string, string> = {
+        bind: "Two features align; one disanalogy is noted.",
+        counterpoint: "Inverted motif. Counter view.",
+        canonize: "",
+        refute: "",
+      };
+      const justification = justificationMap[type] ?? "";
       if (justification.length > effect.justificationLimit) return false;
     }
     return true;
@@ -181,6 +193,119 @@ export default function App() {
     }
   };
 
+  const liftMove = async () => {
+    if (!playerId || !state || selected.length !== 1 || !twistAllows("lift")) return;
+    const targetId = selected[0];
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "lift",
+      payload: { targetId },
+      timestamp: Date.now(),
+      durationMs: 800,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+      setSelected([]);
+    } catch (err) {
+      console.error("Failed to lift", err);
+    }
+  };
+
+  const canonizeMove = async () => {
+    if (!playerId || !state || selected.length !== 1 || !twistAllows("canonize")) return;
+    const targetId = selected[0];
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "canonize",
+      payload: { targetId },
+      timestamp: Date.now(),
+      durationMs: 800,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+      setSelected([]);
+    } catch (err) {
+      console.error("Failed to canonize", err);
+    }
+  };
+
+  const refuteMove = async () => {
+    if (!playerId || !state || selected.length !== 1 || !twistAllows("refute")) return;
+    const targetId = selected[0];
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "refute",
+      payload: { targetId },
+      timestamp: Date.now(),
+      durationMs: 800,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+      setSelected([]);
+    } catch (err) {
+      console.error("Failed to refute", err);
+    }
+  };
+
+  const pruneMove = async () => {
+    if (!playerId || !state || selected.length !== 1 || !twistAllows("prune")) return;
+    const targetId = selected[0];
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "prune",
+      payload: { targetId },
+      timestamp: Date.now(),
+      durationMs: 800,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+      setSelected([]);
+    } catch (err) {
+      console.error("Failed to prune", err);
+    }
+  };
+
+  const jokerMove = async () => {
+    if (!playerId || !state || !twistAllows("joker")) return;
+    const move: Move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId,
+      type: "joker",
+      payload: {},
+      timestamp: Date.now(),
+      durationMs: 800,
+      valid: true,
+    };
+    try {
+      await api(`/match/${state.id}/move`, {
+        method: "POST",
+        body: JSON.stringify(move),
+      });
+    } catch (err) {
+      console.error("Failed to play joker", err);
+    }
+  };
+
   const drawTwist = async () => {
     if (!state) return;
     try {
@@ -307,6 +432,41 @@ export default function App() {
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Counterpoint Selected
+          </button>
+          <button
+            onClick={liftMove}
+            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("lift")}
+            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Lift
+          </button>
+          <button
+            onClick={canonizeMove}
+            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("canonize")}
+            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Canonize
+          </button>
+          <button
+            onClick={refuteMove}
+            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("refute")}
+            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Refute
+          </button>
+          <button
+            onClick={pruneMove}
+            disabled={!isMyTurn || selected.length !== 1 || !twistAllows("prune")}
+            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Prune
+          </button>
+          <button
+            onClick={jokerMove}
+            disabled={!isMyTurn || !twistAllows("joker")}
+            className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Joker
           </button>
           <button onClick={requestJudgment} disabled={!isMyTurn} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed">Request Judgment</button>
           <button onClick={exportLog} className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Export Log</button>

--- a/apps/web/src/GraphView.test.tsx
+++ b/apps/web/src/GraphView.test.tsx
@@ -51,3 +51,21 @@ test('renders cathedral node when present', async () => {
     expect(cathedralNode?.getAttribute('fill')).toBe('#fbbf24');
   });
 });
+
+test('updates when state prop changes', async () => {
+  const { container, rerender } = render(
+    <GraphView state={state} width={200} height={200} />
+  );
+  await waitFor(() => {
+    expect(container.querySelectorAll('circle').length).toBe(2);
+  });
+  const catState: GameState = {
+    ...state,
+    cathedral: { id: 'cat', content: 'summary', references: ['a'] },
+  };
+  rerender(<GraphView state={catState} width={200} height={200} />);
+  await waitFor(() => {
+    const cathedralNode = container.querySelector('#cat');
+    expect(cathedralNode).not.toBeNull();
+  });
+});

--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -14,6 +14,8 @@ interface Link extends d3.SimulationLinkDatum<Node> {
 export interface GraphViewProps {
   /** Match id to connect to websocket and receive live state */
   matchId?: string;
+  /** Game state provided directly, bypassing websocket */
+  state?: GameState;
   /** Initial state to render if websocket not used */
   initialState?: GameState;
   /** Strong paths from judgment scroll for highlighting */
@@ -30,6 +32,7 @@ export interface GraphViewProps {
 
 export default function GraphView({
   matchId,
+  state: propState,
   initialState,
   strongPaths,
   selectedPathIndex,
@@ -38,7 +41,11 @@ export default function GraphView({
   width = 800,
   height = 600,
 }: GraphViewProps) {
-  const { state } = useMatchState(matchId, { initialState });
+  const { state: liveState } = useMatchState(matchId, {
+    initialState,
+    autoConnect: !propState,
+  });
+  const state = propState || liveState;
   const svgRef = useRef<SVGSVGElement | null>(null);
   const simulationRef = useRef<d3.Simulation<Node, Link> | null>(null);
 


### PR DESCRIPTION
## Summary
- add UI buttons for lift, canonize, refute, prune, and joker
- post new move types using current selection
- respect twist constraints for canonize and refute

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0de07e53c832caba6148b2a3c9d4b