### PR TITLE
Add Concord request and state-aware graph

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -54,6 +54,13 @@ describe('App', () => {
           text: async () => '',
         });
       }
+      if (u.endsWith(`/match/${mockState.id}/concord`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ cathedral: { id: 'cat', content: 'C', references: ['b1'] } }),
+          text: async () => '',
+        });
+      }
       return Promise.reject(new Error('Unknown endpoint'));
     });
   });
@@ -171,5 +178,40 @@ describe('App', () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText('Share an idea...')).toHaveValue('AI idea')
     );
+  });
+
+  it('requests concord and updates graph', async () => {
+    const { container } = render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    const concordButton = screen.getByRole('button', { name: 'Concord' });
+    await waitFor(() => expect(concordButton).not.toBeDisabled());
+    fireEvent.click(concordButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/concord`),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      const cathedralNode = container.querySelector('#cat');
+      expect(cathedralNode).not.toBeNull();
+    });
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -216,6 +216,19 @@ export default function App() {
     }
   };
 
+  const requestConcord = async () => {
+    if (!state) return;
+    try {
+      const res = await api(`/match/${state.id}/concord`, { method: "POST" });
+      const data = await res.json();
+      if (data?.cathedral) {
+        setState((s) => (s ? { ...s, cathedral: data.cathedral } : s));
+      }
+    } catch (err) {
+      console.error("Failed to request concord", err);
+    }
+  };
+
   const exportLog = async () => {
     if (!state) return;
     try {
@@ -309,6 +322,7 @@ export default function App() {
             Counterpoint Selected
           </button>
           <button onClick={requestJudgment} disabled={!isMyTurn} className="w-full px-3 py-2 bg-emerald-600 rounded hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed">Request Judgment</button>
+          <button onClick={requestConcord} disabled={!isMyTurn} className="w-full px-3 py-2 bg-amber-600 rounded hover:bg-amber-500 disabled:opacity-50 disabled:cursor-not-allowed">Concord</button>
           <button onClick={exportLog} className="w-full px-3 py-2 bg-zinc-800 rounded hover:bg-zinc-700">Export Log</button>
         </div>
         <p className="text-xs text-[var(--muted)] pt-4">MVP: cast text beads, bind, get a stub judgment.</p>
@@ -371,7 +385,7 @@ export default function App() {
                 <section className="lg:col-span-2">
                   <h3 className="text-sm uppercase tracking-wide text-[var(--muted)]">Graph</h3>
                   <div className="mt-2">
-                    <GraphView matchId={matchId} strongPaths={scroll?.strongPaths} selectedPathIndex={selectedPath} width={600} height={400} />
+                    <GraphView matchId={matchId} state={state ?? undefined} strongPaths={scroll?.strongPaths} selectedPathIndex={selectedPath} width={600} height={400} />
                   </div>
                 </section>
               </div>

--- a/apps/web/src/GraphView.test.tsx
+++ b/apps/web/src/GraphView.test.tsx
@@ -51,3 +51,21 @@ test('renders cathedral node when present', async () => {
     expect(cathedralNode?.getAttribute('fill')).toBe('#fbbf24');
   });
 });
+
+test('updates when state prop changes', async () => {
+  const { container, rerender } = render(
+    <GraphView state={state} width={200} height={200} />
+  );
+  await waitFor(() => {
+    expect(container.querySelectorAll('circle').length).toBe(2);
+  });
+  const catState: GameState = {
+    ...state,
+    cathedral: { id: 'cat', content: 'summary', references: ['a'] },
+  };
+  rerender(<GraphView state={catState} width={200} height={200} />);
+  await waitFor(() => {
+    const cathedralNode = container.querySelector('#cat');
+    expect(cathedralNode).not.toBeNull();
+  });
+});

--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -14,6 +14,8 @@ interface Link extends d3.SimulationLinkDatum<Node> {
 export interface GraphViewProps {
   /** Match id to connect to websocket and receive live state */
   matchId?: string;
+  /** Game state provided directly, bypassing websocket */
+  state?: GameState;
   /** Initial state to render if websocket not used */
   initialState?: GameState;
   /** Strong paths from judgment scroll for highlighting */
@@ -30,6 +32,7 @@ export interface GraphViewProps {
 
 export default function GraphView({
   matchId,
+  state: propState,
   initialState,
   strongPaths,
   selectedPathIndex,
@@ -38,7 +41,11 @@ export default function GraphView({
   width = 800,
   height = 600,
 }: GraphViewProps) {
-  const { state } = useMatchState(matchId, { initialState });
+  const { state: liveState } = useMatchState(matchId, {
+    initialState,
+    autoConnect: !propState,
+  });
+  const state = propState || liveState;
   const svgRef = useRef<SVGSVGElement | null>(null);
   const simulationRef = useRef<d3.Simulation<Node, Link> | null>(null);
 


### PR DESCRIPTION
## Summary
- Implement `requestConcord` to POST to `/match/:id/concord` and update cathedral state
- Add "Concord" button gated by turn
- Pass match state to `GraphView` and support state prop
- Expand tests for graph state updates and concord flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0de09dbcc832c971341aad22eced5