### PR TITLE
Display resources and enforce move costs

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "npm --workspace @gbg/types run build && tsc -p tsconfig.json --noEmit",
     "pretest": "npm --workspace @gbg/types run build && npm run build",
     "test": "node --test --import tsx test/*.test.ts"
   },

--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
-    '^@gbg/types$': '<rootDir>/../../packages/types/src',
+    '^@gbg/types$': '<rootDir>/../../packages/types/dist/index.js',
     '^d3$': '<rootDir>/../../node_modules/d3/dist/d3.js',
     '^./App$': '<rootDir>/src/App.tsx',
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm --workspace @gbg/types run build",
     "test": "jest"
   },
   "dependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import type { GameState, Bead, Move, JudgmentScroll } from "@gbg/types";
+import { MOVE_COSTS, type GameState, type Bead, type Move, type JudgmentScroll } from "@gbg/types";
 import GraphView from "./GraphView";
 import Ladder from "./Ladder";
 import useMatchState from "./hooks/useMatchState";
@@ -30,6 +30,35 @@ export default function App() {
   const { state, setState, connect } = useMatchState(undefined, { autoConnect: false });
   const currentPlayer = state?.players.find(p => p.id === state.currentPlayerId);
   const isMyTurn = currentPlayer?.id === playerId;
+
+  const remainingResources = (type: Move["type"]) => {
+    if (!currentPlayer) return null;
+    const cost = MOVE_COSTS[type] ?? {};
+    let { insight, restraint, wildAvailable } = currentPlayer.resources;
+    if (cost.insight) {
+      if (insight >= cost.insight) {
+        insight -= cost.insight;
+      } else if (wildAvailable) {
+        wildAvailable = false;
+        insight = 0;
+      } else {
+        return null;
+      }
+    }
+    if (cost.restraint) {
+      if (restraint >= cost.restraint) {
+        restraint -= cost.restraint;
+      } else if (wildAvailable) {
+        wildAvailable = false;
+        restraint = 0;
+      } else {
+        return null;
+      }
+    }
+    return { insight, restraint, wildAvailable };
+  };
+
+  const canAfford = (type: Move["type"]) => !!remainingResources(type);
 
   const twistAllows = (type: Move["type"]): boolean => {
     const effect = state?.twist?.effect;
@@ -252,6 +281,11 @@ export default function App() {
             <p className="text-sm mt-1">
               {currentPlayer?.handle || currentPlayer?.id || ""} {isMyTurn && "(your turn)"}
             </p>
+            {currentPlayer && (
+              <p className="text-xs mt-1">
+                Insight: {currentPlayer.resources.insight}, Restraint: {currentPlayer.resources.restraint}, Wild: {currentPlayer.resources.wildAvailable ? 1 : 0}
+              </p>
+            )}
           </div>
         )}
         <div className="pt-4">
@@ -289,21 +323,21 @@ export default function App() {
           </button>
           <button
             onClick={castBead}
-            disabled={!beadText.trim() || !isMyTurn || !twistAllows("cast")}
+            disabled={!beadText.trim() || !isMyTurn || !twistAllows("cast") || !canAfford("cast")}
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Cast Bead
           </button>
           <button
             onClick={bindSelected}
-            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("bind")}
+            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("bind") || !canAfford("bind")}
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Bind Selected
           </button>
           <button
             onClick={counterpointSelected}
-            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("counterpoint")}
+            disabled={!isMyTurn || selected.length !== 2 || !twistAllows("counterpoint") || !canAfford("counterpoint")}
             className="w-full px-3 py-2 bg-indigo-600 rounded hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Counterpoint Selected

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -123,7 +123,7 @@ export function validateSeed(seed: Seed): boolean {
  */
 export interface ValidationResult { ok: boolean; error?: string }
 
-const MOVE_COSTS: Record<MoveType, { insight?: number; restraint?: number }> = {
+export const MOVE_COSTS: Record<MoveType, { insight?: number; restraint?: number }> = {
   cast: { insight: 1 },
   bind: { restraint: 1 },
   transmute: { insight: 1 },
@@ -272,4 +272,4 @@ export function replayMoves(initial: GameState, moves: Move[]): GameState {
 }
 
 // graph utilities
-export * from './graph.js';
+export * from './graph';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -272,4 +272,4 @@ export function replayMoves(initial: GameState, moves: Move[]): GameState {
 }
 
 // graph utilities
-export * from './graph';
+export * from './graph.js';


### PR DESCRIPTION
## Summary
- Show current player's insight, restraint, and wild token in the sidebar
- Enforce move costs with MOVE_COSTS and disable buttons when resources are insufficient
- Export MOVE_COSTS for client use and fix graph export path

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0de0bfe34832caa58561918c340d2