### PR TITLE
feat(web): add advanced move controls (merge main)

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -54,6 +54,13 @@ describe('App', () => {
           text: async () => '',
         });
       }
+      if (u.endsWith(`/match/${mockState.id}/concord`)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ cathedral: { id: 'cat', content: 'C', references: ['b1'] } }),
+          text: async () => '',
+        });
+      }
       return Promise.reject(new Error('Unknown endpoint'));
     });
   });
@@ -139,6 +146,56 @@ describe('App', () => {
     expect(bead2).not.toHaveAttribute('aria-selected', 'true');
   });
 
+  it('mirrors a selected bead and resets selection', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Idea 1')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Modality'), {
+      target: { value: 'image' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Share an idea...'), {
+      target: { value: 'Mirror bead' },
+    });
+
+    const bead1 = await screen.findByTestId('bead-b1');
+    fireEvent.click(bead1);
+
+    const mirrorButton = screen.getByRole('button', { name: 'Mirror Selected' });
+    fireEvent.click(mirrorButton);
+
+    await waitFor(() => {
+      const moveCall = (global.fetch as jest.Mock).mock.calls.find(c =>
+        (c[0] as string).includes('/move')
+      );
+      expect(moveCall).toBeTruthy();
+      const body = JSON.parse(moveCall![1].body as string);
+      expect(body.type).toBe('mirror');
+      expect(body.payload.targetId).toBe('b1');
+      expect(body.payload.bead.modality).toBe('image');
+    });
+
+    await waitFor(() => expect(mirrorButton).toBeDisabled());
+    expect(bead1).not.toHaveAttribute('aria-selected', 'true');
+  });
+
   it('populates textarea with AI suggestion', async () => {
     render(<App />);
 
@@ -171,5 +228,40 @@ describe('App', () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText('Share an idea...')).toHaveValue('AI idea')
     );
+  });
+
+  it('requests concord and updates graph', async () => {
+    const { container } = render(<App />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g., MagisterRex'), {
+      target: { value: 'Alice' },
+    });
+
+    fireEvent.click(screen.getByText('Create'));
+    await screen.findByText(/Seed 1/);
+
+    fireEvent.click(screen.getByText('Join'));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/join`),
+        expect.any(Object)
+      );
+    });
+
+    const concordButton = screen.getByRole('button', { name: 'Concord' });
+    await waitFor(() => expect(concordButton).not.toBeDisabled());
+    fireEvent.click(concordButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/match/${mockState.id}/concord`),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    await waitFor(() => {
+      const cathedralNode = container.querySelector('#cat');
+      expect(cathedralNode).not.toBeNull();
+    });
   });
 });

--- a/apps/web/src/GraphView.test.tsx
+++ b/apps/web/src/GraphView.test.tsx
@@ -51,3 +51,21 @@ test('renders cathedral node when present', async () => {
     expect(cathedralNode?.getAttribute('fill')).toBe('#fbbf24');
   });
 });
+
+test('updates when state prop changes', async () => {
+  const { container, rerender } = render(
+    <GraphView state={state} width={200} height={200} />
+  );
+  await waitFor(() => {
+    expect(container.querySelectorAll('circle').length).toBe(2);
+  });
+  const catState: GameState = {
+    ...state,
+    cathedral: { id: 'cat', content: 'summary', references: ['a'] },
+  };
+  rerender(<GraphView state={catState} width={200} height={200} />);
+  await waitFor(() => {
+    const cathedralNode = container.querySelector('#cat');
+    expect(cathedralNode).not.toBeNull();
+  });
+});

--- a/apps/web/src/GraphView.tsx
+++ b/apps/web/src/GraphView.tsx
@@ -14,6 +14,8 @@ interface Link extends d3.SimulationLinkDatum<Node> {
 export interface GraphViewProps {
   /** Match id to connect to websocket and receive live state */
   matchId?: string;
+  /** Game state provided directly, bypassing websocket */
+  state?: GameState;
   /** Initial state to render if websocket not used */
   initialState?: GameState;
   /** Strong paths from judgment scroll for highlighting */
@@ -30,6 +32,7 @@ export interface GraphViewProps {
 
 export default function GraphView({
   matchId,
+  state: propState,
   initialState,
   strongPaths,
   selectedPathIndex,
@@ -38,7 +41,11 @@ export default function GraphView({
   width = 800,
   height = 600,
 }: GraphViewProps) {
-  const { state } = useMatchState(matchId, { initialState });
+  const { state: liveState } = useMatchState(matchId, {
+    initialState,
+    autoConnect: !propState,
+  });
+  const state = propState || liveState;
   const svgRef = useRef<SVGSVGElement | null>(null);
   const simulationRef = useRef<d3.Simulation<Node, Link> | null>(null);
 


### PR DESCRIPTION
## Summary
- integrate latest `main` into advanced move controls
- handle twist constraints for canonize/refute and add lift/prune/joker moves
- expose UI buttons for new move types

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0e1b7ad4c832c834ca8ff6a781cc1