### PR TITLE
Display resources and enforce move costs

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
-    '^@gbg/types$': '<rootDir>/../../packages/types/src',
+    '^@gbg/types$': '<rootDir>/../../packages/types/dist/index.js',
     '^d3$': '<rootDir>/../../node_modules/d3/dist/d3.js',
     '^./App$': '<rootDir>/src/App.tsx',
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm --workspace @gbg/types run build",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -272,4 +272,4 @@ export function replayMoves(initial: GameState, moves: Move[]): GameState {
 }
 
 // graph utilities
-export * from './graph';
+export * from './graph.js';


### PR DESCRIPTION
## Summary
- Export graph utilities with explicit `.js` extension to satisfy ESM resolution
- Build types package before web tests and use compiled types in Jest

## Testing
- `npm --workspace apps/web run test`
- `npm --workspace apps/server run test`
- `npm --workspace packages/types run test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0e7b95374832ca39c9b476c801399