### PR TITLE
feat(web): render sanitized markdown

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -17,6 +17,6 @@ module.exports = {
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(d3|d3-[^/]+|internmap|delaunator|robust-predicates)/)',
+    'node_modules/(?!(d3|d3-[^/]+|internmap|delaunator|robust-predicates|marked)/)',
   ]
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "d3": "^7.9.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "marked": "^16.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from "react";
 import {
   MOVE_COSTS,
+  sanitizeMarkdown,
   type GameState,
   type Bead,
   type Move,
   type JudgmentScroll,
   type Modality,
 } from "@gbg/types";
+import { marked } from "marked";
 import GraphView from "./GraphView";
 import Ladder from "./Ladder";
 import useMatchState from "./hooks/useMatchState";
@@ -632,7 +634,10 @@ export default function App() {
                       >
                         <div className="text-sm font-semibold">{b.title || b.id}</div>
                         <div className="text-xs opacity-70">{b.modality} · by {b.ownerId}</div>
-                        <div className="text-xs mt-1 opacity-80">{tryParseMarkdown(b.content)}</div>
+                        <div
+                          className="text-xs mt-1 opacity-80"
+                          dangerouslySetInnerHTML={{ __html: parseMarkdown(b.content) }}
+                        />
                       </li>
                     ))}
                   </ul>
@@ -701,6 +706,7 @@ export default function App() {
   );
 }
 
-function tryParseMarkdown(content: string){
-  return content;
+function parseMarkdown(content: string): string {
+  const html = marked.parse(content, { async: false }) as string;
+  return sanitizeMarkdown(html);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "version": "0.1.0",
       "dependencies": {
         "d3": "^7.9.0",
+        "marked": "^16.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -11233,6 +11234,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.2.1.tgz",
+      "integrity": "sha512-r3UrXED9lMlHF97jJByry90cwrZBBvZmjG1L68oYfuPMW+uDTnuMbyJDymCWwbTE+f+3LhpNDKfpR3a3saFyjA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {


### PR DESCRIPTION
## Summary
- render bead content as sanitized markdown using marked
- allow Jest to transform the marked module

## Testing
- `npm run test:web`

------
https://chatgpt.com/codex/tasks/task_e_68c16682c8f8832cbef1b18ccde674f6