### PR TITLE
fix build order for shared types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:web": "npm --workspace apps/web run dev",
     "dev:server": "npm --workspace apps/server run dev",
     "dev:types": "npm --workspace packages/types run dev",
-    "build": "npm-run-all -p build:*",
+    "build": "npm-run-all build:types && npm-run-all -p build:web build:server",
     "build:web": "npm --workspace apps/web run build",
     "build:server": "npm --workspace apps/server run build",
     "build:types": "npm --workspace packages/types run build",


### PR DESCRIPTION
## Summary
- ensure shared `@gbg/types` package builds before web/server builds to prevent outdated `JudgedScores`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16d2fc8fc832ca36acbdfb7a08032