### PR TITLE
Improve LLM seed parsing

### DIFF
--- a/apps/server/test/seeds-llm.test.ts
+++ b/apps/server/test/seeds-llm.test.ts
@@ -41,3 +41,35 @@ test('generateSeeds falls back to sample seeds on error', async (t) => {
   const seeds = await generateSeeds(client);
   assert.deepEqual(seeds, sampleSeeds());
 });
+
+test('generateSeeds extracts JSON array from prose or code fences', async (t) => {
+  const prev = process.env.LLM_MODEL;
+  process.env.LLM_MODEL = 'test';
+  t.after(() => {
+    if (prev === undefined) delete process.env.LLM_MODEL;
+    else process.env.LLM_MODEL = prev;
+  });
+  const client = {
+    generate() {
+      return (async function* () {
+        yield [
+          'Here are some seeds:',
+          '```json',
+          JSON.stringify([
+            { text: 'Astrophysics', domain: 'science' },
+            { text: 'Cubism', domain: 'art' }
+          ]),
+          '```',
+          'Enjoy!'
+        ].join('\n');
+      })();
+    }
+  };
+  const seeds = await generateSeeds(client);
+  const sample = sampleSeeds();
+  assert.equal(seeds.length, 3);
+  assert.equal(seeds[0].text, 'Astrophysics');
+  assert.equal(seeds[1].domain, 'art');
+  assert.equal(seeds[2].text, sample[0].text);
+  assert.equal(seeds[2].domain, sample[0].domain);
+});


### PR DESCRIPTION
## Summary
- Parse seeds from first JSON array in LLM output and pad with sample seeds
- Test LLM seed parser against code fences and extra text

## Testing
- `npm --workspace apps/server test`


------
https://chatgpt.com/codex/tasks/task_e_68c1719042e8832c887af3d2358bd3c0