### PR TITLE
docs: add refresh build instructions

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,3 +28,19 @@ npm --workspace apps/web run test
 ```
 
 The built assets will be output to `dist/`.
+
+## Refresh build
+
+After pulling new code, refresh the build to pick up new buttons and dropdowns.
+From the repository root run one of:
+
+```bash
+npm --workspace apps/web run dev
+# or
+npm --workspace apps/web run build
+# or
+./start-dev.sh
+```
+
+If the interface still shows the old layout, clear your browser cache or
+restart Vite.


### PR DESCRIPTION
## Summary
- document how to refresh the web client build after pulling new code

## Testing
- `CI=1 npm --workspace apps/web run test` *(fails: process hangs after invoking jest)*
- `npm --workspace apps/web run typecheck` *(fails: Cannot find module 'marked')*


------
https://chatgpt.com/codex/tasks/task_e_68c1737c5f58832cab9d607f4b481af5