### PR TITLE
feat: configure API base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-error.log*
 
 # Environment variables
 .env
+!apps/web/.env
 
 # Misc
 .DS_Store

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8787

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -9,6 +9,15 @@ storage for convenience. An AI suggestion button can propose bead ideas, and
 match state is managed by the `useMatchState` hook to keep the UI in sync via
 WebSockets.
 
+## Configuration
+
+Create an `.env` file to override defaults. To point the client at a different
+API server, set `VITE_API_BASE` (defaults to `http://localhost:8787`):
+
+```bash
+VITE_API_BASE=http://localhost:8787
+```
+
 ## Development
 
 Run workspace scripts from the repository root:

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+}));
 import App from './App';
 
 class MockWebSocket {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { marked } from "marked";
 import GraphView from "./GraphView";
 import Ladder from "./Ladder";
 import useMatchState from "./hooks/useMatchState";
+import api from "./api";
 
 const AXIS_INFO = {
   resonance: {
@@ -41,20 +42,6 @@ const AXIS_INFO = {
   },
 } as const;
 
-// Helper around fetch that only sets the JSON content type when a body is
-// present (Fastify returns 400 on an empty JSON body) and throws on HTTP
-// errors.
-const api = async (path: string, opts: RequestInit = {}) => {
-  const headers = opts.body
-    ? { "Content-Type": "application/json", ...(opts.headers || {}) }
-    : opts.headers;
-  const res = await fetch(`http://localhost:8787${path}`, { ...opts, headers });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `Request failed with ${res.status}`);
-  }
-  return res;
-};
 
 export default function App() {
   const [matchId, setMatchId] = useState<string>(() => localStorage.getItem("matchId") || "");

--- a/apps/web/src/Ladder.test.tsx
+++ b/apps/web/src/Ladder.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+}));
 import Ladder from './Ladder';
 
 describe('Ladder', () => {

--- a/apps/web/src/Ladder.tsx
+++ b/apps/web/src/Ladder.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import api from "./api";
 
 interface Rating {
   handle: string;
@@ -13,7 +14,7 @@ export default function Ladder() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch("http://localhost:8787/ratings");
+        const res = await api("/ratings");
         if (res.ok) {
           const data = await res.json();
           setStandings(data);

--- a/apps/web/src/Twist.test.tsx
+++ b/apps/web/src/Twist.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+}));
 import App from './App';
 
 class MockWebSocket {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,20 @@
+const API_BASE =
+  // @ts-ignore - import.meta may not be available in tests
+  (typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_API_BASE) ||
+  (typeof process !== "undefined" && process.env.VITE_API_BASE) ||
+  "http://localhost:8787";
+
+export const api = async (path: string, opts: RequestInit = {}) => {
+  const headers = opts.body
+    ? { "Content-Type": "application/json", ...(opts.headers || {}) }
+    : opts.headers;
+  const res = await fetch(`${API_BASE}${path}`, { ...opts, headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Request failed with ${res.status}`);
+  }
+  return res;
+};
+
+export { API_BASE };
+export default api;


### PR DESCRIPTION
## Summary
- allow configuring API base URL via `VITE_API_BASE`
- use shared API helper in app components
- document new environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1737b9adc832c868df26aac25a6e7