### PR TITLE
docs: add about me page

### DIFF
--- a/aboutme.md
+++ b/aboutme.md
@@ -1,0 +1,96 @@
+Hi, I’m Josh Farrow
+
+Clinical–AI solutions architect, BCBA/LBA by training, and builder of memory-centric AI systems.
+I spent ~15 years in behavior analysis and now work at the seam of information theory, cognition, and tooling—from emergent-physics ideas to practical, HIPAA-aware automation.
+
+I like projects that reduce friction for real people (especially attention/language differences), make meaning primary over form, and let ideas grow in an organismic, “tapestry” way rather than rigid product cadences.
+
+⸻
+
+## Background (why I’m here)
+- Behavior analyst → AI engineer. I’ve led clinical ops and data projects, then co-founded an AI/LLM startup building HIPAA-conscious prototypes (Python, React, LangChain, Azure Data Explorer).
+- Bridges over silos. I design systems that connect human workflows (intake, documentation, QA, feedback) with models that actually remember and adapt.
+- Research curiosities. Emergent laws from information, memory architectures, “POSIWID” framing (the purpose of a system is what it does), narrative dynamics, and sentiment/macro signals.
+
+⸻
+
+## Motivations
+- Meaning > Form. Writing and UI are gatekeepers; tools should amplify ideas for people who think/communicate differently.
+- Memory is the frontier. Great systems accumulate context across time, modalities, and goals—then use it to act.
+- Agency & feedback. I build things that shorten the loop between observation → representation → intervention.
+
+⸻
+
+## Selected projects
+
+Links go to public repos when available; some are papers/demos in progress. PRs and issues welcome.
+
+1) Semantic Tensor Memory
+
+A higher-order memory system that tracks meaning across time × tokens × embeddings, enabling retrieval and reasoning that respect narrative evolution.
+- Stack: Python, vector DB, lightweight evaluators; planning a React/Three.js viz.
+- Repo: semantic_tensor_memory (coming) • Paper draft (coming)
+
+2) FogSight — Sentiment Saturation Index
+
+A dashboard + weekly brief for narrative climate in markets (equities + crypto), blending flows, positioning, and headline saturation into actionable zones.
+- Stack: Python, pandas, plotting, Sheets/CSV adapters; RAG for notes.
+- Status: active • Private prototype; public notes forthcoming
+
+3) Algorithm Mirror
+
+Monitors social algorithms with periodic screenshots → VLM analysis → trend tracking to expose what the feed is optimizing you toward.
+- Stack: Python, VLMs, local OCR; privacy-respecting by default.
+- Status: early prototype
+
+4) QATNU / SRQID (speculative research)
+
+Framework sketches for emergent physical laws from self-referential information dynamics and gauge promotions in tensor networks.
+- Outputs: LaTeX drafts, toy simulations, 3D visualizations (Three.js).
+- Papers (drafts): QATNU/SRQID (preprint WIP)
+
+5) Glass Bead Game (Hesse-inspired, AI-judged)
+
+Two-player online game where players weave cross-domain “beads” (math, music, poetry, code) into a coherent motif; AI serves as the impartial judge.
+- Repo: warrofua/glass-bead-game
+- Roadmap: schema for rounds/judging, constraints deck, minimal Web UI
+
+6) Gamma Studies (options microstructure)
+
+Pipeline to compute net gamma over time from broker JSON in Postgres (JSONB), correlated with underlying moves and expiry structure.
+- Stack: Python, SQL, scheduled ETL; plotting and anomaly flags.
+- Status: internal notebooks → open-sourcing sanitized code
+
+⸻
+
+## Ideas & frames I’m exploring
+- Information Primacy: many modern pathologies are mis-wired information loops; fix the loops, not just the outputs.
+- Narrative scars: stable patterns laid into systems by repeated attention/ritual; useful lens for institutions and markets.
+- Memory-augmented agents: personal OS that fuses typed text, audio, screenshots into a time-aligned, queryable memory.
+
+⸻
+
+## Selected tools & stack
+- Languages: Python, TypeScript
+- Front-end: React, Three.js, Tailwind
+- Data: Postgres/JSONB, Azure Data Explorer, vector DBs
+- AI: LLMs/VLMs, LangChain/RAG patterns, lightweight eval harnesses
+- Ops: Notebooks → scripts → dashboards, privacy-first by default
+
+⸻
+
+## How I like to work
+- Triage to traction: ship thin vertical slices that prove the loop (sense → decide → act → learn).
+- Readable by design: docstrings, typed data classes, small examples.
+- Measurement over vibes: even speculative systems get sanity checks and falsifiable hooks.
+
+⸻
+
+## Collaborate / contact
+- Open to research collaborations, tooling partnerships, and consulting on memory systems, clinical AI, and narrative analytics.
+- Best way to reach me: open an issue here or start a Discussion on any repo. (If you need a direct line, ping me there and I’ll share it.)
+
+⸻
+
+## Changelog
+- 2025-09-10: First public pass of this about_me.md. Will evolve as projects graduate from notebooks to rep_.


### PR DESCRIPTION
## Summary
- add personal about me page with background, projects, and contact info

## Testing
- `CI=true npm --workspace apps/web run test -- --watchAll=false` (fails: command hangs in jest)


------
https://chatgpt.com/codex/tasks/task_e_68c1ca2d15b0832c8c7231d0192abf19