### PR TITLE
feat: configure API base

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -4,6 +4,7 @@ jest.mock('./api', () => ({
   __esModule: true,
   default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
   api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  WS_BASE: 'ws://localhost:8787',
 }));
 import App from './App';
 

--- a/apps/web/src/GraphView.test.tsx
+++ b/apps/web/src/GraphView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
+jest.mock('./api', () => ({ __esModule: true, WS_BASE: 'ws://localhost:8787' }));
 import GraphView from './GraphView';
 import type { GameState } from '@gbg/types';
 

--- a/apps/web/src/Ladder.test.tsx
+++ b/apps/web/src/Ladder.test.tsx
@@ -4,6 +4,7 @@ jest.mock('./api', () => ({
   __esModule: true,
   default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
   api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  WS_BASE: 'ws://localhost:8787',
 }));
 import Ladder from './Ladder';
 

--- a/apps/web/src/Twist.test.tsx
+++ b/apps/web/src/Twist.test.tsx
@@ -4,6 +4,7 @@ jest.mock('./api', () => ({
   __esModule: true,
   default: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
   api: (path: string, opts?: RequestInit) => fetch(`http://localhost:8787${path}`, opts),
+  WS_BASE: 'ws://localhost:8787',
 }));
 import App from './App';
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -4,6 +4,8 @@ const API_BASE =
   (typeof process !== "undefined" && process.env.VITE_API_BASE) ||
   "http://localhost:8787";
 
+const WS_BASE = API_BASE.replace(/^http/, "ws");
+
 export const api = async (path: string, opts: RequestInit = {}) => {
   const headers = opts.body
     ? { "Content-Type": "application/json", ...(opts.headers || {}) }
@@ -16,5 +18,5 @@ export const api = async (path: string, opts: RequestInit = {}) => {
   return res;
 };
 
-export { API_BASE };
+export { API_BASE, WS_BASE };
 export default api;

--- a/apps/web/src/hooks/useMatchState.test.tsx
+++ b/apps/web/src/hooks/useMatchState.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+jest.mock('../api', () => ({ WS_BASE: 'ws://localhost:8787' }));
 import useMatchState from './useMatchState';
 import type { GameState } from '@gbg/types';
 

--- a/apps/web/src/hooks/useMatchState.ts
+++ b/apps/web/src/hooks/useMatchState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { GameState } from "@gbg/types";
+import { WS_BASE } from "../api";
 
 interface WsMsg {
   type: string;
@@ -36,7 +37,7 @@ export default function useMatchState(
       if (!targetId) return;
       // Close any existing connection
       wsRef.current?.close();
-      const ws = new WebSocket(`ws://localhost:8787/?matchId=${targetId}`);
+      const ws = new WebSocket(`${WS_BASE}/?matchId=${targetId}`);
       ws.onmessage = (e) => {
         try {
           const msg: WsMsg = JSON.parse(e.data);


### PR DESCRIPTION
## Summary
- allow configuring API base URL via `VITE_API_BASE`
- use shared API helper in app components
- document new environment variable
- derive WebSocket endpoint from `API_BASE`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c22607be54832c81c074c26a308e82