### PR TITLE
Require two players before accepting moves

### DIFF
--- a/apps/server/src/routes/move.ts
+++ b/apps/server/src/routes/move.ts
@@ -46,6 +46,9 @@ export default function registerMoveRoute(
           );
         }
       }
+      if (state.players.length < 2) {
+        return reply.code(400).send({ error: "Need two players to proceed" });
+      }
       const validation = validateMove(move, state);
       if (!validation.ok) {
         return reply.code(400).send({ error: validation.error });

--- a/apps/server/test/concord.test.ts
+++ b/apps/server/test/concord.test.ts
@@ -22,6 +22,32 @@ test('concord builds cathedral from highest path', async (t) => {
     }).then((r) => r.json());
 
   const p1 = await join('Alice');
+  const p2 = await join('Bob');
+
+  const dummy = async () => {
+    const bead = {
+      id: randomId('b'),
+      ownerId: p2.id,
+      modality: 'text',
+      content: 'dummy',
+      complexity: 1,
+      createdAt: Date.now(),
+    };
+    const move = {
+      id: randomId('m'),
+      playerId: p2.id,
+      type: 'cast' as const,
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true,
+    };
+    await fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move),
+    });
+  };
 
   const castBead = async (id: string, title: string) => {
     const bead = {
@@ -52,7 +78,9 @@ test('concord builds cathedral from highest path', async (t) => {
   const b1 = randomId('b');
   const b2 = randomId('b');
   await castBead(b1, 'First');
+  await dummy();
   await castBead(b2, 'Second');
+  await dummy();
 
   const bindMove = {
     id: randomId('m'),

--- a/apps/server/test/moves.test.ts
+++ b/apps/server/test/moves.test.ts
@@ -18,6 +18,32 @@ test('cast rejects when insight and wild exhausted', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
+  const p2 = await join('B');
+
+  const dummy = async () => {
+    const bead = {
+      id: `b_${Math.random().toString(36).slice(2,8)}`,
+      ownerId: p2.id,
+      modality: 'text',
+      content: 'y',
+      complexity: 1,
+      createdAt: Date.now()
+    };
+    const move = {
+      id: `m_${Math.random().toString(36).slice(2,8)}`,
+      playerId: p2.id,
+      type: 'cast',
+      payload: { bead },
+      timestamp: Date.now(),
+      durationMs: 0,
+      valid: true
+    };
+    await fetch(`${base}/match/${matchId}/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(move)
+    });
+  };
 
   const cast = async () => {
     const bead = {
@@ -48,6 +74,7 @@ test('cast rejects when insight and wild exhausted', async (t) => {
   for(let i=0;i<6;i++){
     const res = await cast();
     assert.equal(res.status, 200);
+    await dummy();
   }
 
   // verify resources exhausted
@@ -79,6 +106,13 @@ test('bind uses restraint then wild then rejects', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
+  const p2 = await join('B');
+
+  const dummy = async () => {
+    const bead = { id: `b_${Math.random().toString(36).slice(2,8)}`, ownerId: p2.id, modality: 'text', content: 'y', complexity:1, createdAt:Date.now() };
+    const move = { id:`m_${Math.random().toString(36).slice(2,8)}`, playerId:p2.id, type:'cast', payload:{ bead }, timestamp:Date.now(), durationMs:0, valid:true };
+    await fetch(`${base}/match/${matchId}/move`, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(move)});
+  };
 
   // cast two beads to bind
   const castBead = async (id:string) => {
@@ -88,7 +122,7 @@ test('bind uses restraint then wild then rejects', async (t) => {
   };
   const b1 = `b_${Math.random().toString(36).slice(2,8)}`;
   const b2 = `b_${Math.random().toString(36).slice(2,8)}`;
-  await castBead(b1); await castBead(b2);
+  await castBead(b1); await dummy(); await castBead(b2); await dummy();
 
   const bind = async () => {
     const move = {
@@ -111,6 +145,7 @@ test('bind uses restraint then wild then rejects', async (t) => {
   for(let i=0;i<3;i++){
     const res = await bind();
     assert.equal(res.status, 200);
+    await dummy();
   }
 
   // fourth bind should be rejected

--- a/apps/server/test/twist.test.ts
+++ b/apps/server/test/twist.test.ts
@@ -18,6 +18,13 @@ test('twist rejects bind with wrong relation', async (t) => {
     }).then(r => r.json());
 
   const p1 = await join('A');
+  const p2 = await join('B');
+
+  const dummy = async () => {
+    const bead = { id:`b_${Math.random().toString(36).slice(2,8)}`, ownerId:p2.id, modality:'text', content:'x', complexity:1, createdAt: Date.now() };
+    const move = { id:`m_${Math.random().toString(36).slice(2,8)}`, playerId:p2.id, type:'cast', payload:{ bead }, timestamp:Date.now(), durationMs:0, valid:true };
+    await fetch(`${base}/match/${matchId}/move`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(move) });
+  };
 
   const castBead = async (id:string) => {
     const bead = { id, ownerId: p1.id, modality: 'text', content: 'x', complexity:1, createdAt: Date.now() };
@@ -28,7 +35,9 @@ test('twist rejects bind with wrong relation', async (t) => {
   const b1 = `b_${Math.random().toString(36).slice(2,8)}`;
   const b2 = `b_${Math.random().toString(36).slice(2,8)}`;
   await castBead(b1);
+  await dummy();
   await castBead(b2);
+  await dummy();
 
   // draw twists twice to reach requiredRelation twist
   await fetch(`${base}/match/${matchId}/twist`, { method:'POST' });

--- a/apps/server/test/two-players.test.ts
+++ b/apps/server/test/two-players.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { startServer } from './server.helper.js';
+
+const makeMove = (playerId: string) => {
+  const bead = {
+    id: `b_${Math.random().toString(36).slice(2,8)}`,
+    ownerId: playerId,
+    modality: 'text',
+    content: 'x',
+    complexity: 1,
+    createdAt: Date.now()
+  };
+  return {
+    id: `m_${Math.random().toString(36).slice(2,8)}`,
+    playerId,
+    type: 'cast',
+    payload: { bead },
+    timestamp: Date.now(),
+    durationMs: 0,
+    valid: true
+  };
+};
+
+test('second move rejected until another player joins', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.kill());
+  const base = `http://127.0.0.1:${port}`;
+
+  const matchRes = await fetch(`${base}/match`, { method: 'POST' });
+  const match = await matchRes.json();
+  const matchId = match.id as string;
+
+  const join = (handle: string) =>
+    fetch(`${base}/match/${matchId}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle })
+    }).then(r => r.json());
+
+  const p1 = await join('Alice');
+
+  let res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(makeMove(p1.id))
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Need two players to proceed');
+
+  res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(makeMove(p1.id))
+  });
+  assert.equal(res.status, 400);
+
+  await join('Bob');
+
+  res = await fetch(`${base}/match/${matchId}/move`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(makeMove(p1.id))
+  });
+  assert.equal(res.status, 200);
+});
+


### PR DESCRIPTION
## Summary
- require two players in move handler before validating a move
- add unit test ensuring moves are rejected until a second player joins
- update existing tests to include a second player and alternate turns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c32daa7110832cb084aa7b7b15edd7